### PR TITLE
Upgrade Nuked OPL3 emulator to 1.8 and only resample audio if not run…

### DIFF
--- a/apogee/driver/fmopl3lib/opl3.cpp
+++ b/apogee/driver/fmopl3lib/opl3.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2016 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -20,8 +20,10 @@
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.7.1
+// version: 1.8
 //
 
 #include <stdio.h>
@@ -92,41 +94,41 @@ static const Bit16u logsinrom[256] = {
 //
 
 static const Bit16u exprom[256] = {
-    0x000, 0x003, 0x006, 0x008, 0x00b, 0x00e, 0x011, 0x014,
-    0x016, 0x019, 0x01c, 0x01f, 0x022, 0x025, 0x028, 0x02a,
-    0x02d, 0x030, 0x033, 0x036, 0x039, 0x03c, 0x03f, 0x042,
-    0x045, 0x048, 0x04b, 0x04e, 0x051, 0x054, 0x057, 0x05a,
-    0x05d, 0x060, 0x063, 0x066, 0x069, 0x06c, 0x06f, 0x072,
-    0x075, 0x078, 0x07b, 0x07e, 0x082, 0x085, 0x088, 0x08b,
-    0x08e, 0x091, 0x094, 0x098, 0x09b, 0x09e, 0x0a1, 0x0a4,
-    0x0a8, 0x0ab, 0x0ae, 0x0b1, 0x0b5, 0x0b8, 0x0bb, 0x0be,
-    0x0c2, 0x0c5, 0x0c8, 0x0cc, 0x0cf, 0x0d2, 0x0d6, 0x0d9,
-    0x0dc, 0x0e0, 0x0e3, 0x0e7, 0x0ea, 0x0ed, 0x0f1, 0x0f4,
-    0x0f8, 0x0fb, 0x0ff, 0x102, 0x106, 0x109, 0x10c, 0x110,
-    0x114, 0x117, 0x11b, 0x11e, 0x122, 0x125, 0x129, 0x12c,
-    0x130, 0x134, 0x137, 0x13b, 0x13e, 0x142, 0x146, 0x149,
-    0x14d, 0x151, 0x154, 0x158, 0x15c, 0x160, 0x163, 0x167,
-    0x16b, 0x16f, 0x172, 0x176, 0x17a, 0x17e, 0x181, 0x185,
-    0x189, 0x18d, 0x191, 0x195, 0x199, 0x19c, 0x1a0, 0x1a4,
-    0x1a8, 0x1ac, 0x1b0, 0x1b4, 0x1b8, 0x1bc, 0x1c0, 0x1c4,
-    0x1c8, 0x1cc, 0x1d0, 0x1d4, 0x1d8, 0x1dc, 0x1e0, 0x1e4,
-    0x1e8, 0x1ec, 0x1f0, 0x1f5, 0x1f9, 0x1fd, 0x201, 0x205,
-    0x209, 0x20e, 0x212, 0x216, 0x21a, 0x21e, 0x223, 0x227,
-    0x22b, 0x230, 0x234, 0x238, 0x23c, 0x241, 0x245, 0x249,
-    0x24e, 0x252, 0x257, 0x25b, 0x25f, 0x264, 0x268, 0x26d,
-    0x271, 0x276, 0x27a, 0x27f, 0x283, 0x288, 0x28c, 0x291,
-    0x295, 0x29a, 0x29e, 0x2a3, 0x2a8, 0x2ac, 0x2b1, 0x2b5,
-    0x2ba, 0x2bf, 0x2c4, 0x2c8, 0x2cd, 0x2d2, 0x2d6, 0x2db,
-    0x2e0, 0x2e5, 0x2e9, 0x2ee, 0x2f3, 0x2f8, 0x2fd, 0x302,
-    0x306, 0x30b, 0x310, 0x315, 0x31a, 0x31f, 0x324, 0x329,
-    0x32e, 0x333, 0x338, 0x33d, 0x342, 0x347, 0x34c, 0x351,
-    0x356, 0x35b, 0x360, 0x365, 0x36a, 0x370, 0x375, 0x37a,
-    0x37f, 0x384, 0x38a, 0x38f, 0x394, 0x399, 0x39f, 0x3a4,
-    0x3a9, 0x3ae, 0x3b4, 0x3b9, 0x3bf, 0x3c4, 0x3c9, 0x3cf,
-    0x3d4, 0x3da, 0x3df, 0x3e4, 0x3ea, 0x3ef, 0x3f5, 0x3fa
+    0x7fa, 0x7f5, 0x7ef, 0x7ea, 0x7e4, 0x7df, 0x7da, 0x7d4,
+    0x7cf, 0x7c9, 0x7c4, 0x7bf, 0x7b9, 0x7b4, 0x7ae, 0x7a9,
+    0x7a4, 0x79f, 0x799, 0x794, 0x78f, 0x78a, 0x784, 0x77f,
+    0x77a, 0x775, 0x770, 0x76a, 0x765, 0x760, 0x75b, 0x756,
+    0x751, 0x74c, 0x747, 0x742, 0x73d, 0x738, 0x733, 0x72e,
+    0x729, 0x724, 0x71f, 0x71a, 0x715, 0x710, 0x70b, 0x706,
+    0x702, 0x6fd, 0x6f8, 0x6f3, 0x6ee, 0x6e9, 0x6e5, 0x6e0,
+    0x6db, 0x6d6, 0x6d2, 0x6cd, 0x6c8, 0x6c4, 0x6bf, 0x6ba,
+    0x6b5, 0x6b1, 0x6ac, 0x6a8, 0x6a3, 0x69e, 0x69a, 0x695,
+    0x691, 0x68c, 0x688, 0x683, 0x67f, 0x67a, 0x676, 0x671,
+    0x66d, 0x668, 0x664, 0x65f, 0x65b, 0x657, 0x652, 0x64e,
+    0x649, 0x645, 0x641, 0x63c, 0x638, 0x634, 0x630, 0x62b,
+    0x627, 0x623, 0x61e, 0x61a, 0x616, 0x612, 0x60e, 0x609,
+    0x605, 0x601, 0x5fd, 0x5f9, 0x5f5, 0x5f0, 0x5ec, 0x5e8,
+    0x5e4, 0x5e0, 0x5dc, 0x5d8, 0x5d4, 0x5d0, 0x5cc, 0x5c8,
+    0x5c4, 0x5c0, 0x5bc, 0x5b8, 0x5b4, 0x5b0, 0x5ac, 0x5a8,
+    0x5a4, 0x5a0, 0x59c, 0x599, 0x595, 0x591, 0x58d, 0x589,
+    0x585, 0x581, 0x57e, 0x57a, 0x576, 0x572, 0x56f, 0x56b,
+    0x567, 0x563, 0x560, 0x55c, 0x558, 0x554, 0x551, 0x54d,
+    0x549, 0x546, 0x542, 0x53e, 0x53b, 0x537, 0x534, 0x530,
+    0x52c, 0x529, 0x525, 0x522, 0x51e, 0x51b, 0x517, 0x514,
+    0x510, 0x50c, 0x509, 0x506, 0x502, 0x4ff, 0x4fb, 0x4f8,
+    0x4f4, 0x4f1, 0x4ed, 0x4ea, 0x4e7, 0x4e3, 0x4e0, 0x4dc,
+    0x4d9, 0x4d6, 0x4d2, 0x4cf, 0x4cc, 0x4c8, 0x4c5, 0x4c2,
+    0x4be, 0x4bb, 0x4b8, 0x4b5, 0x4b1, 0x4ae, 0x4ab, 0x4a8,
+    0x4a4, 0x4a1, 0x49e, 0x49b, 0x498, 0x494, 0x491, 0x48e,
+    0x48b, 0x488, 0x485, 0x482, 0x47e, 0x47b, 0x478, 0x475,
+    0x472, 0x46f, 0x46c, 0x469, 0x466, 0x463, 0x460, 0x45d,
+    0x45a, 0x457, 0x454, 0x451, 0x44e, 0x44b, 0x448, 0x445,
+    0x442, 0x43f, 0x43c, 0x439, 0x436, 0x433, 0x430, 0x42d,
+    0x42a, 0x428, 0x425, 0x422, 0x41f, 0x41c, 0x419, 0x416,
+    0x414, 0x411, 0x40e, 0x40b, 0x408, 0x406, 0x403, 0x400
 };
 
-// 
+//
 // freq mult table multiplied by 2
 //
 // 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 12, 12, 15, 15
@@ -152,33 +154,11 @@ static const Bit8u kslshift[4] = {
 // envelope generator constants
 //
 
-static const Bit8u eg_incstep[3][4][8] = {
-    {
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 }
-    },
-    {
-        { 0, 1, 0, 1, 0, 1, 0, 1 },
-        { 0, 1, 0, 1, 1, 1, 0, 1 },
-        { 0, 1, 1, 1, 0, 1, 1, 1 },
-        { 0, 1, 1, 1, 1, 1, 1, 1 }
-    },
-    {
-        { 1, 1, 1, 1, 1, 1, 1, 1 },
-        { 2, 2, 1, 1, 1, 1, 1, 1 },
-        { 2, 2, 1, 1, 2, 2, 1, 1 },
-        { 2, 2, 2, 2, 2, 2, 1, 1 }
-    }
-};
-
-static const Bit8u eg_incdesc[16] = {
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2
-};
-
-static const Bit8s eg_incsh[16] = {
-    0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, -1, -2
+static const Bit8u eg_incstep[4][4] = {
+    { 0, 0, 0, 0 },
+    { 1, 0, 0, 0 },
+    { 1, 0, 1, 0 },
+    { 1, 1, 1, 0 }
 };
 
 //
@@ -207,7 +187,7 @@ static Bit16s OPL3_EnvelopeCalcExp(Bit32u level)
     {
         level = 0x1fff;
     }
-    return ((exprom[(level & 0xff) ^ 0xff] | 0x400) << 1) >> (level >> 8);
+    return (exprom[level & 0xff] << 1) >> (level >> 8);
 }
 
 static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
@@ -217,7 +197,7 @@ static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     if (phase & 0x100)
     {
@@ -286,7 +266,7 @@ static Bit16s OPL3_EnvelopeCalcSin4(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if ((phase & 0x300) == 0x100)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     if (phase & 0x200)
     {
@@ -328,7 +308,7 @@ static Bit16s OPL3_EnvelopeCalcSin6(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     return OPL3_EnvelopeCalcExp(envelope << 3) ^ neg;
 }
@@ -340,7 +320,7 @@ static Bit16s OPL3_EnvelopeCalcSin7(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
         phase = (phase & 0x1ff) ^ 0x1ff;
     }
     out = phase << 3;
@@ -358,44 +338,13 @@ static const envelope_sinfunc envelope_sin[8] = {
     OPL3_EnvelopeCalcSin7
 };
 
-static void OPL3_EnvelopeGenOff(opl3_slot *slot);
-static void OPL3_EnvelopeGenAttack(opl3_slot *slot);
-static void OPL3_EnvelopeGenDecay(opl3_slot *slot);
-static void OPL3_EnvelopeGenSustain(opl3_slot *slot);
-static void OPL3_EnvelopeGenRelease(opl3_slot *slot);
-
-envelope_genfunc envelope_gen[5] = {
-    OPL3_EnvelopeGenOff,
-    OPL3_EnvelopeGenAttack,
-    OPL3_EnvelopeGenDecay,
-    OPL3_EnvelopeGenSustain,
-    OPL3_EnvelopeGenRelease
-};
-
 enum envelope_gen_num
 {
-    envelope_gen_num_off = 0,
-    envelope_gen_num_attack = 1,
-    envelope_gen_num_decay = 2,
-    envelope_gen_num_sustain = 3,
-    envelope_gen_num_release = 4
+    envelope_gen_num_attack = 0,
+    envelope_gen_num_decay = 1,
+    envelope_gen_num_sustain = 2,
+    envelope_gen_num_release = 3
 };
-
-static Bit8u OPL3_EnvelopeCalcRate(opl3_slot *slot, Bit8u reg_rate)
-{
-    Bit8u rate;
-    if (reg_rate == 0x00)
-    {
-        return 0x00;
-    }
-    rate = (reg_rate << 2)
-         + (slot->reg_ksr ? slot->channel->ksv : (slot->channel->ksv >> 2));
-    if (rate > 0x3c)
-    {
-        rate = 0x3c;
-    }
-    return rate;
-}
 
 static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
 {
@@ -408,128 +357,161 @@ static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
     slot->eg_ksl = (Bit8u)ksl;
 }
 
-static void OPL3_EnvelopeUpdateRate(opl3_slot *slot)
-{
-    switch (slot->eg_gen)
-    {
-    case envelope_gen_num_off:
-    case envelope_gen_num_attack:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_ar);
-        break;
-    case envelope_gen_num_decay:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_dr);
-        break;
-    case envelope_gen_num_sustain:
-    case envelope_gen_num_release:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_rr);
-        break;
-    }
-}
-
-static void OPL3_EnvelopeGenOff(opl3_slot *slot)
-{
-    slot->eg_rout = 0x1ff;
-}
-
-static void OPL3_EnvelopeGenAttack(opl3_slot *slot)
-{
-    if (slot->eg_rout == 0x00)
-    {
-        slot->eg_gen = envelope_gen_num_decay;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += ((~slot->eg_rout) * slot->eg_inc) >> 3;
-    if (slot->eg_rout < 0x00)
-    {
-        slot->eg_rout = 0x00;
-    }
-}
-
-static void OPL3_EnvelopeGenDecay(opl3_slot *slot)
-{
-    if (slot->eg_rout >= slot->reg_sl << 4)
-    {
-        slot->eg_gen = envelope_gen_num_sustain;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
-static void OPL3_EnvelopeGenSustain(opl3_slot *slot)
-{
-    if (!slot->reg_type)
-    {
-        OPL3_EnvelopeGenRelease(slot);
-    }
-}
-
-static void OPL3_EnvelopeGenRelease(opl3_slot *slot)
-{
-    if (slot->eg_rout >= 0x1ff)
-    {
-        slot->eg_gen = envelope_gen_num_off;
-        slot->eg_rout = 0x1ff;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
 static void OPL3_EnvelopeCalc(opl3_slot *slot)
 {
-    Bit8u rate_h, rate_l;
-    Bit8u inc = 0;
-    rate_h = slot->eg_rate >> 2;
-    rate_l = slot->eg_rate & 3;
-    if (eg_incsh[rate_h] > 0)
+    Bit8u nonzero;
+    Bit8u rate;
+    Bit8u rate_hi;
+    Bit8u rate_lo;
+    Bit8u reg_rate = 0;
+    Bit8u ks;
+    Bit8u eg_shift, shift;
+    Bit16u eg_rout;
+    Bit16s eg_inc;
+    Bit8u eg_off;
+    Bit8u reset = 0;
+    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
+                 + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
+    if (slot->key && slot->eg_gen == envelope_gen_num_release)
     {
-        if ((slot->chip->timer & ((1 << eg_incsh[rate_h]) - 1)) == 0)
-        {
-            inc = eg_incstep[eg_incdesc[rate_h]][rate_l]
-                            [((slot->chip->timer)>> eg_incsh[rate_h]) & 0x07];
-        }
+        reset = 1;
+        reg_rate = slot->reg_ar;
     }
     else
     {
-        inc = eg_incstep[eg_incdesc[rate_h]][rate_l]
-                        [slot->chip->timer & 0x07] << (-eg_incsh[rate_h]);
+        switch (slot->eg_gen)
+        {
+        case envelope_gen_num_attack:
+            reg_rate = slot->reg_ar;
+            break;
+        case envelope_gen_num_decay:
+            reg_rate = slot->reg_dr;
+            break;
+        case envelope_gen_num_sustain:
+            if (!slot->reg_type)
+            {
+                reg_rate = slot->reg_rr;
+            }
+            break;
+        case envelope_gen_num_release:
+            reg_rate = slot->reg_rr;
+            break;
+        }
     }
-    slot->eg_inc = inc;
-    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
-                 + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
-    envelope_gen[slot->eg_gen](slot);
+    slot->pg_reset = reset;
+    ks = slot->channel->ksv >> ((slot->reg_ksr ^ 1) << 1);
+    nonzero = (reg_rate != 0);
+    rate = ks + (reg_rate << 2);
+    rate_hi = rate >> 2;
+    rate_lo = rate & 0x03;
+    if (rate_hi & 0x10)
+    {
+        rate_hi = 0x0f;
+    }
+    eg_shift = rate_hi + slot->chip->eg_add;
+    shift = 0;
+    if (nonzero)
+    {
+        if (rate_hi < 12)
+        {
+            if (slot->chip->eg_state)
+            {
+                switch (eg_shift)
+                {
+                case 12:
+                    shift = 1;
+                    break;
+                case 13:
+                    shift = (rate_lo >> 1) & 0x01;
+                    break;
+                case 14:
+                    shift = rate_lo & 0x01;
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+        else
+        {
+            shift = (rate_hi & 0x03) + eg_incstep[rate_lo][slot->chip->timer & 0x03];
+            if (shift & 0x04)
+            {
+                shift = 0x03;
+            }
+            if (!shift)
+            {
+                shift = slot->chip->eg_state;
+            }
+        }
+    }
+    eg_rout = slot->eg_rout;
+    eg_inc = 0;
+    eg_off = 0;
+    // Instant attack
+    if (reset && rate_hi == 0x0f)
+    {
+        eg_rout = 0x00;
+    }
+    // Envelope off
+    if ((slot->eg_rout & 0x1f8) == 0x1f8)
+    {
+        eg_off = 1;
+    }
+    if (slot->eg_gen != envelope_gen_num_attack && !reset && eg_off)
+    {
+        eg_rout = 0x1ff;
+    }
+    switch (slot->eg_gen)
+    {
+    case envelope_gen_num_attack:
+        if (!slot->eg_rout)
+        {
+            slot->eg_gen = envelope_gen_num_decay;
+        }
+        else if (slot->key && shift > 0 && rate_hi != 0x0f)
+        {
+            eg_inc = ((~slot->eg_rout) << shift) >> 4;
+        }
+        break;
+    case envelope_gen_num_decay:
+        if ((slot->eg_rout >> 4) == slot->reg_sl)
+        {
+            slot->eg_gen = envelope_gen_num_sustain;
+        }
+        else if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
+        break;
+    case envelope_gen_num_sustain:
+    case envelope_gen_num_release:
+        if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
+        break;
+    }
+    slot->eg_rout = (eg_rout + eg_inc) & 0x1ff;
+    // Key off
+    if (reset)
+    {
+        slot->eg_gen = envelope_gen_num_attack;
+    }
+    if (!slot->key)
+    {
+        slot->eg_gen = envelope_gen_num_release;
+    }
 }
 
 static void OPL3_EnvelopeKeyOn(opl3_slot *slot, Bit8u type)
 {
-    if (!slot->key)
-    {
-        slot->eg_gen = envelope_gen_num_attack;
-        OPL3_EnvelopeUpdateRate(slot);
-        if ((slot->eg_rate >> 2) == 0x0f)
-        {
-            slot->eg_gen = envelope_gen_num_decay;
-            OPL3_EnvelopeUpdateRate(slot);
-            slot->eg_rout = 0x00;
-        }
-        slot->pg_phase = 0x00;
-    }
     slot->key |= type;
 }
 
 static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
 {
-    if (slot->key)
-    {
-        slot->key &= (~type);
-        if (!slot->key)
-        {
-            slot->eg_gen = envelope_gen_num_release;
-            OPL3_EnvelopeUpdateRate(slot);
-        }
-    }
+    slot->key &= ~type;
 }
 
 //
@@ -538,9 +520,14 @@ static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
 
 static void OPL3_PhaseGenerate(opl3_slot *slot)
 {
+    opl3_chip *chip;
     Bit16u f_num;
     Bit32u basefreq;
+    Bit8u rm_xor, n_bit;
+    Bit32u noise;
+    Bit16u phase;
 
+    chip = slot->chip;
     f_num = slot->channel->f_num;
     if (slot->reg_vib)
     {
@@ -567,20 +554,58 @@ static void OPL3_PhaseGenerate(opl3_slot *slot)
         f_num += range;
     }
     basefreq = (f_num << slot->channel->block) >> 1;
-    slot->pg_phase += (basefreq * mt[slot->reg_mult]) >> 1;
-}
-
-//
-// Noise Generator
-//
-
-static void OPL3_NoiseGenerate(opl3_chip *chip)
-{
-    if (chip->noise & 0x01)
+    phase = (Bit16u)(slot->pg_phase >> 9);
+    if (slot->pg_reset)
     {
-        chip->noise ^= 0x800302;
+        slot->pg_phase = 0;
     }
-    chip->noise >>= 1;
+    slot->pg_phase += (basefreq * mt[slot->reg_mult]) >> 1;
+    // Rhythm mode
+    noise = chip->noise;
+    slot->pg_phase_out = phase;
+    if (slot->slot_num == 13) // hh
+    {
+        chip->rm_hh_bit2 = (phase >> 2) & 1;
+        chip->rm_hh_bit3 = (phase >> 3) & 1;
+        chip->rm_hh_bit7 = (phase >> 7) & 1;
+        chip->rm_hh_bit8 = (phase >> 8) & 1;
+    }
+    if (slot->slot_num == 17 && (chip->rhy & 0x20)) // tc
+    {
+        chip->rm_tc_bit3 = (phase >> 3) & 1;
+        chip->rm_tc_bit5 = (phase >> 5) & 1;
+    }
+    if (chip->rhy & 0x20)
+    {
+        rm_xor = (chip->rm_hh_bit2 ^ chip->rm_hh_bit7)
+               | (chip->rm_hh_bit3 ^ chip->rm_tc_bit5)
+               | (chip->rm_tc_bit3 ^ chip->rm_tc_bit5);
+        switch (slot->slot_num)
+        {
+        case 13: // hh
+            slot->pg_phase_out = rm_xor << 9;
+            if (rm_xor ^ (noise & 1))
+            {
+                slot->pg_phase_out |= 0xd0;
+            }
+            else
+            {
+                slot->pg_phase_out |= 0x34;
+            }
+            break;
+        case 16: // sd
+            slot->pg_phase_out = (chip->rm_hh_bit8 << 9)
+                               | ((chip->rm_hh_bit8 ^ (noise & 1)) << 8);
+            break;
+        case 17: // tc
+            slot->pg_phase_out = (rm_xor << 9) | 0x80;
+            break;
+        default:
+            break;
+        }
+    }
+    n_bit = ((noise >> 14) ^ noise) & 0x01;
+    chip->noise = (noise >> 1) | (n_bit << 22);
 }
 
 //
@@ -601,7 +626,6 @@ static void OPL3_SlotWrite20(opl3_slot *slot, Bit8u data)
     slot->reg_type = (data >> 5) & 0x01;
     slot->reg_ksr = (data >> 4) & 0x01;
     slot->reg_mult = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWrite40(opl3_slot *slot, Bit8u data)
@@ -615,7 +639,6 @@ static void OPL3_SlotWrite60(opl3_slot *slot, Bit8u data)
 {
     slot->reg_ar = (data >> 4) & 0x0f;
     slot->reg_dr = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
@@ -626,7 +649,6 @@ static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
         slot->reg_sl = 0x1f;
     }
     slot->reg_rr = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
@@ -638,19 +660,9 @@ static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
     }
 }
 
-static void OPL3_SlotGeneratePhase(opl3_slot *slot, Bit16u phase)
-{
-    slot->out = envelope_sin[slot->reg_wf](phase, slot->eg_out);
-}
-
 static void OPL3_SlotGenerate(opl3_slot *slot)
 {
-    OPL3_SlotGeneratePhase(slot, (Bit16u)(slot->pg_phase >> 9) + *slot->mod);
-}
-
-static void OPL3_SlotGenerateZM(opl3_slot *slot)
-{
-    OPL3_SlotGeneratePhase(slot, (Bit16u)(slot->pg_phase >> 9));
+    slot->out = envelope_sin[slot->reg_wf](slot->pg_phase_out + *slot->mod, slot->eg_out);
 }
 
 static void OPL3_SlotCalcFB(opl3_slot *slot)
@@ -702,6 +714,8 @@ static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
             chip->channel[chnum].chtype = ch_drum;
         }
         OPL3_ChannelSetupAlg(channel6);
+        OPL3_ChannelSetupAlg(channel7);
+        OPL3_ChannelSetupAlg(channel8);
         //hh
         if (chip->rhy & 0x01)
         {
@@ -756,6 +770,8 @@ static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
         {
             chip->channel[chnum].chtype = ch_2op;
             OPL3_ChannelSetupAlg(&chip->channel[chnum]);
+            OPL3_EnvelopeKeyOff(chip->channel[chnum].slots[0], egk_drum);
+            OPL3_EnvelopeKeyOff(chip->channel[chnum].slots[1], egk_drum);
         }
     }
 }
@@ -771,16 +787,12 @@ static void OPL3_ChannelWriteA0(opl3_channel *channel, Bit8u data)
                  | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
     OPL3_EnvelopeUpdateKSL(channel->slots[0]);
     OPL3_EnvelopeUpdateKSL(channel->slots[1]);
-    OPL3_EnvelopeUpdateRate(channel->slots[0]);
-    OPL3_EnvelopeUpdateRate(channel->slots[1]);
     if (channel->chip->newm && channel->chtype == ch_4op)
     {
         channel->pair->f_num = channel->f_num;
         channel->pair->ksv = channel->ksv;
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[0]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[1]);
     }
 }
 
@@ -796,8 +808,6 @@ static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
                  | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
     OPL3_EnvelopeUpdateKSL(channel->slots[0]);
     OPL3_EnvelopeUpdateKSL(channel->slots[1]);
-    OPL3_EnvelopeUpdateRate(channel->slots[0]);
-    OPL3_EnvelopeUpdateRate(channel->slots[1]);
     if (channel->chip->newm && channel->chtype == ch_4op)
     {
         channel->pair->f_num = channel->f_num;
@@ -805,8 +815,6 @@ static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
         channel->pair->ksv = channel->ksv;
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[0]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[1]);
     }
 }
 
@@ -814,6 +822,12 @@ static void OPL3_ChannelSetupAlg(opl3_channel *channel)
 {
     if (channel->chtype == ch_drum)
     {
+        if (channel->ch_num == 7 || channel->ch_num == 8)
+        {
+            channel->slots[0]->mod = &channel->chip->zeromod;
+            channel->slots[1]->mod = &channel->chip->zeromod;
+            return;
+        }
         switch (channel->alg & 0x01)
         {
         case 0x00:
@@ -940,7 +954,7 @@ static void OPL3_ChannelWriteC0(opl3_channel *channel, Bit8u data)
     }
     else
     {
-        channel->cha = channel->chb = ~0;
+        channel->cha = channel->chb = (Bit16u)~0;
     }
 }
 
@@ -1029,94 +1043,21 @@ static Bit16s OPL3_ClipSample(Bit32s sample)
     return (Bit16s)sample;
 }
 
-static void OPL3_GenerateRhythm1(opl3_chip *chip)
-{
-    opl3_channel *channel6;
-    opl3_channel *channel7;
-    opl3_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    OPL3_SlotGenerate(channel6->slots[0]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04)
-             | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //hh
-    phase = (phasebit << 9)
-          | (0x34 << ((phasebit ^ (chip->noise & 0x01) << 1)));
-    OPL3_SlotGeneratePhase(channel7->slots[0], phase);
-    //tt
-    OPL3_SlotGenerateZM(channel8->slots[0]);
-}
-
-static void OPL3_GenerateRhythm2(opl3_chip *chip)
-{
-    opl3_channel *channel6;
-    opl3_channel *channel7;
-    opl3_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    OPL3_SlotGenerate(channel6->slots[1]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04)
-             | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //sd
-    phase = (0x100 << ((phase14 >> 8) & 0x01)) ^ ((chip->noise & 0x01) << 8);
-    OPL3_SlotGeneratePhase(channel7->slots[1], phase);
-    //tc
-    phase = 0x100 | (phasebit << 9);
-    OPL3_SlotGeneratePhase(channel8->slots[1], phase);
-}
-
 void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
 {
     Bit8u ii;
     Bit8u jj;
     Bit16s accm;
+    Bit8u shift = 0;
 
     buf[1] = OPL3_ClipSample(chip->mixbuff[1]);
 
-    for (ii = 0; ii < 12; ii++)
+    for (ii = 0; ii < 15; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
-    }
-
-    for (ii = 12; ii < 15; ii++)
-    {
-        OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
-        OPL3_EnvelopeCalc(&chip->slot[ii]);
-    }
-
-    if (chip->rhy & 0x20)
-    {
-        OPL3_GenerateRhythm1(chip);
-    }
-    else
-    {
-        OPL3_SlotGenerate(&chip->slot[12]);
-        OPL3_SlotGenerate(&chip->slot[13]);
-        OPL3_SlotGenerate(&chip->slot[14]);
     }
 
     chip->mixbuff[0] = 0;
@@ -1133,19 +1074,9 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 15; ii < 18; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
-    }
-
-    if (chip->rhy & 0x20)
-    {
-        OPL3_GenerateRhythm2(chip);
-    }
-    else
-    {
-        OPL3_SlotGenerate(&chip->slot[15]);
-        OPL3_SlotGenerate(&chip->slot[16]);
-        OPL3_SlotGenerate(&chip->slot[17]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
+        OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
     buf[0] = OPL3_ClipSample(chip->mixbuff[0]);
@@ -1153,8 +1084,8 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 18; ii < 33; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
@@ -1172,24 +1103,22 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 33; ii < 36; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
     }
-
-    OPL3_NoiseGenerate(chip);
 
     if ((chip->timer & 0x3f) == 0x3f)
     {
         chip->tremolopos = (chip->tremolopos + 1) % 210;
-        if (chip->tremolopos < 105)
-        {
-            chip->tremolo = chip->tremolopos >> chip->tremoloshift;
-        }
-        else
-        {
-            chip->tremolo = (210 - chip->tremolopos) >> chip->tremoloshift;
-        }
+    }
+    if (chip->tremolopos < 105)
+    {
+        chip->tremolo = chip->tremolopos >> chip->tremoloshift;
+    }
+    else
+    {
+        chip->tremolo = (210 - chip->tremolopos) >> chip->tremoloshift;
     }
 
     if ((chip->timer & 0x3ff) == 0x3ff)
@@ -1198,6 +1127,52 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     }
 
     chip->timer++;
+
+    chip->eg_add = 0;
+    if (chip->eg_timer)
+    {
+        while (shift < 36 && ((chip->eg_timer >> shift) & 1) == 0)
+        {
+            shift++;
+        }
+        if (shift > 12)
+        {
+            chip->eg_add = 0;
+        }
+        else
+        {
+            chip->eg_add = shift + 1;
+        }
+    }
+
+    if (chip->eg_timerrem || chip->eg_state)
+    {
+        if (chip->eg_timer == 0xfffffffff)
+        {
+            chip->eg_timer = 0;
+            chip->eg_timerrem = 1;
+        }
+        else
+        {
+            chip->eg_timer++;
+            chip->eg_timerrem = 0;
+        }
+    }
+
+    chip->eg_state ^= 1;
+
+    while (chip->writebuf[chip->writebuf_cur].time <= chip->writebuf_samplecnt)
+    {
+        if (!(chip->writebuf[chip->writebuf_cur].reg & 0x200))
+        {
+            break;
+        }
+        chip->writebuf[chip->writebuf_cur].reg &= 0x1ff;
+        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_cur].reg,
+                      chip->writebuf[chip->writebuf_cur].data);
+        chip->writebuf_cur = (chip->writebuf_cur + 1) % OPL_WRITEBUF_SIZE;
+    }
+    chip->writebuf_samplecnt++;
 }
 
 void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf)
@@ -1228,8 +1203,9 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
         chip->slot[slotnum].mod = &chip->zeromod;
         chip->slot[slotnum].eg_rout = 0x1ff;
         chip->slot[slotnum].eg_out = 0x1ff;
-        chip->slot[slotnum].eg_gen = envelope_gen_num_off;
+        chip->slot[slotnum].eg_gen = envelope_gen_num_release;
         chip->slot[slotnum].trem = (Bit8u*)&chip->zeromod;
+        chip->slot[slotnum].slot_num = slotnum;
     }
     for (channum = 0; channum < 18; channum++)
     {
@@ -1251,12 +1227,15 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
         chip->channel[channum].out[2] = &chip->zeromod;
         chip->channel[channum].out[3] = &chip->zeromod;
         chip->channel[channum].chtype = ch_2op;
-        chip->channel[channum].cha = ~0;
-        chip->channel[channum].chb = ~0;
+        chip->channel[channum].cha = 0xffff;
+        chip->channel[channum].chb = 0xffff;
+        chip->channel[channum].ch_num = channum;
         OPL3_ChannelSetupAlg(&chip->channel[channum]);
     }
-    chip->noise = 0x306600;
+    chip->noise = 1;
     chip->rateratio = (samplerate << RSM_FRAC) / 49716;
+    chip->tremoloshift = 4;
+    chip->vibshift = 1;
 }
 
 void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
@@ -1355,5 +1334,51 @@ void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
             OPL3_ChannelWriteC0(&chip->channel[9 * high + (regm & 0x0f)], v);
         }
         break;
+    }
+}
+
+void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v)
+{
+    Bit64u time1, time2;
+
+    if (chip->writebuf[chip->writebuf_last].reg & 0x200)
+    {
+        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_last].reg & 0x1ff,
+                      chip->writebuf[chip->writebuf_last].data);
+
+        chip->writebuf_cur = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+        chip->writebuf_samplecnt = chip->writebuf[chip->writebuf_last].time;
+    }
+
+    chip->writebuf[chip->writebuf_last].reg = reg | 0x200;
+    chip->writebuf[chip->writebuf_last].data = v;
+    time1 = chip->writebuf_lasttime + OPL_WRITEBUF_DELAY;
+    time2 = chip->writebuf_samplecnt;
+
+    if (time1 < time2)
+    {
+        time1 = time2;
+    }
+
+    chip->writebuf[chip->writebuf_last].time = time1;
+    chip->writebuf_lasttime = time1;
+    chip->writebuf_last = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+}
+
+void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
+{
+    Bit32u i;
+
+    for(i = 0; i < numsamples; i++)
+    {
+        if (chip->rateratio == 1 << RSM_FRAC)
+        {
+            OPL3_Generate(chip, sndptr);
+        }
+        else
+        {
+            OPL3_GenerateResampled(chip, sndptr);
+        }
+        sndptr += 2;
     }
 }

--- a/apogee/driver/fmopl3lib/opl3.h
+++ b/apogee/driver/fmopl3lib/opl3.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2016 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -20,20 +20,30 @@
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.7.1
+// version: 1.8
 //
 
-#include <stdint.h>
+#ifndef OPL_OPL3_H
+#define OPL_OPL3_H
 
-typedef uint8_t             Bit8u;
-typedef int8_t              Bit8s;
-typedef uint16_t            Bit16u;
-typedef int16_t             Bit16s;
-typedef uint32_t            Bit32u;
-typedef int32_t             Bit32s;
-typedef uint64_t            Bit64u;
-typedef int64_t             Bit64s;
+#include <inttypes.h>
+
+#define OPL_WRITEBUF_SIZE   1024
+#define OPL_WRITEBUF_DELAY  2
+
+typedef uintptr_t       Bitu;
+typedef intptr_t        Bits;
+typedef uint64_t        Bit64u;
+typedef int64_t         Bit64s;
+typedef uint32_t        Bit32u;
+typedef int32_t         Bit32s;
+typedef uint16_t        Bit16u;
+typedef int16_t         Bit16s;
+typedef uint8_t         Bit8u;
+typedef int8_t          Bit8s;
 
 typedef struct _opl3_slot opl3_slot;
 typedef struct _opl3_channel opl3_channel;
@@ -65,8 +75,10 @@ struct _opl3_slot {
     Bit8u reg_rr;
     Bit8u reg_wf;
     Bit8u key;
+    Bit32u pg_reset;
     Bit32u pg_phase;
-    Bit32u timer;
+    Bit16u pg_phase_out;
+    Bit8u slot_num;
 };
 
 struct _opl3_channel {
@@ -82,12 +94,23 @@ struct _opl3_channel {
     Bit8u alg;
     Bit8u ksv;
     Bit16u cha, chb;
+    Bit8u ch_num;
 };
+
+typedef struct _opl3_writebuf {
+    Bit64u time;
+    Bit16u reg;
+    Bit8u data;
+} opl3_writebuf;
 
 struct _opl3_chip {
     opl3_channel channel[18];
     opl3_slot slot[36];
     Bit16u timer;
+    Bit64u eg_timer;
+    Bit8u eg_timerrem;
+    Bit8u eg_state;
+    Bit8u eg_add;
     Bit8u newm;
     Bit8u nts;
     Bit8u rhy;
@@ -99,14 +122,29 @@ struct _opl3_chip {
     Bit32u noise;
     Bit16s zeromod;
     Bit32s mixbuff[2];
+    Bit8u rm_hh_bit2;
+    Bit8u rm_hh_bit3;
+    Bit8u rm_hh_bit7;
+    Bit8u rm_hh_bit8;
+    Bit8u rm_tc_bit3;
+    Bit8u rm_tc_bit5;
     //OPL3L
     Bit32s rateratio;
     Bit32s samplecnt;
     Bit16s oldsamples[2];
     Bit16s samples[2];
+
+    Bit64u writebuf_samplecnt;
+    Bit32u writebuf_cur;
+    Bit32u writebuf_last;
+    Bit64u writebuf_lasttime;
+    opl3_writebuf writebuf[OPL_WRITEBUF_SIZE];
 };
 
 void OPL3_Generate(opl3_chip *chip, Bit16s *buf);
 void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf);
 void OPL3_Reset(opl3_chip *chip, Bit32u samplerate);
 void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v);
+void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v);
+void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
+#endif

--- a/apogee/driver/fmopl3lib/opl3class.cpp
+++ b/apogee/driver/fmopl3lib/opl3class.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2015-2017 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,48 +15,19 @@
 #include <string.h>
 #include "opl3class.h"
 
-const Bit64u lat = (50 * 49716) / 1000;
-
 
 int opl3class::fm_init(unsigned int rate) {
     OPL3_Reset(&chip, rate);
-
-    memset(command,0,sizeof(command));
-    memset(time, 0, sizeof(time));
-    counter = 0;
-    lastwrite = 0;
-    strpos = 0;
-    endpos = 0;
 
 	return 1;
 }
 
 void opl3class::fm_writereg(unsigned short reg, unsigned char data) {
-    command[endpos % 8192][0] = reg;
-    command[endpos % 8192][1] = data;
-    Bit64u t1 = lastwrite + 2;
-    Bit64u t2 = counter + lat;
-    if (t2 > t1)
-    {
-        t1 = t2;
-    }
-    time[endpos % 8192] = t1;
-    lastwrite = t1;
-    endpos = (endpos + 1) % 8192;
+    OPL3_WriteRegBuffered(&chip, reg, data);
 }
 
 void opl3class::fm_generate(signed short *buffer, unsigned int len) {
-    for (unsigned int i = 0; i < len; i++)
-    {
-        while (strpos != endpos && time[strpos] < counter)
-        {
-            OPL3_WriteReg(&chip, command[strpos][0], command[strpos][1]);
-            strpos = (strpos + 1) % 8192;
-        }
-        OPL3_Generate(&chip, (Bit16s*)buffer);
-        buffer += 2;
-        counter++;
-    }
+    OPL3_GenerateStream(&chip, buffer, len);
 }
 
 fm_chip *getchip() {

--- a/apogee/driver/fmopl3lib/opl3class.h
+++ b/apogee/driver/fmopl3lib/opl3class.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2015-2017 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -12,19 +12,13 @@
 // GNU General Public License for more details.
 //
 
-#include "..\interface.h"
+#include "../interface.h"
 #include "opl3.h"
 
 
 class opl3class : public fm_chip {
 private:
     opl3_chip chip;
-    Bit64u counter;
-    Bit64u lastwrite;
-    Bit16u command[8192][2];
-    Bit64u time[8192];
-    Bit16u strpos;
-    Bit16s endpos;
 public:
 	int fm_init(unsigned int rate);
 	void fm_writereg(unsigned short reg, unsigned char data);

--- a/doomopl/driver/fmopl3lib/opl3.cpp
+++ b/doomopl/driver/fmopl3lib/opl3.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2015 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -20,14 +20,18 @@
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.6.1
+// version: 1.8
 //
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "opl3.h"
+
+#define RSM_FRAC    10
 
 // Channel types
 
@@ -51,22 +55,38 @@ enum {
 //
 
 static const Bit16u logsinrom[256] = {
-    0x859, 0x6c3, 0x607, 0x58b, 0x52e, 0x4e4, 0x4a6, 0x471, 0x443, 0x41a, 0x3f5, 0x3d3, 0x3b5, 0x398, 0x37e, 0x365,
-    0x34e, 0x339, 0x324, 0x311, 0x2ff, 0x2ed, 0x2dc, 0x2cd, 0x2bd, 0x2af, 0x2a0, 0x293, 0x286, 0x279, 0x26d, 0x261,
-    0x256, 0x24b, 0x240, 0x236, 0x22c, 0x222, 0x218, 0x20f, 0x206, 0x1fd, 0x1f5, 0x1ec, 0x1e4, 0x1dc, 0x1d4, 0x1cd,
-    0x1c5, 0x1be, 0x1b7, 0x1b0, 0x1a9, 0x1a2, 0x19b, 0x195, 0x18f, 0x188, 0x182, 0x17c, 0x177, 0x171, 0x16b, 0x166,
-    0x160, 0x15b, 0x155, 0x150, 0x14b, 0x146, 0x141, 0x13c, 0x137, 0x133, 0x12e, 0x129, 0x125, 0x121, 0x11c, 0x118,
-    0x114, 0x10f, 0x10b, 0x107, 0x103, 0x0ff, 0x0fb, 0x0f8, 0x0f4, 0x0f0, 0x0ec, 0x0e9, 0x0e5, 0x0e2, 0x0de, 0x0db,
-    0x0d7, 0x0d4, 0x0d1, 0x0cd, 0x0ca, 0x0c7, 0x0c4, 0x0c1, 0x0be, 0x0bb, 0x0b8, 0x0b5, 0x0b2, 0x0af, 0x0ac, 0x0a9,
-    0x0a7, 0x0a4, 0x0a1, 0x09f, 0x09c, 0x099, 0x097, 0x094, 0x092, 0x08f, 0x08d, 0x08a, 0x088, 0x086, 0x083, 0x081,
-    0x07f, 0x07d, 0x07a, 0x078, 0x076, 0x074, 0x072, 0x070, 0x06e, 0x06c, 0x06a, 0x068, 0x066, 0x064, 0x062, 0x060,
-    0x05e, 0x05c, 0x05b, 0x059, 0x057, 0x055, 0x053, 0x052, 0x050, 0x04e, 0x04d, 0x04b, 0x04a, 0x048, 0x046, 0x045,
-    0x043, 0x042, 0x040, 0x03f, 0x03e, 0x03c, 0x03b, 0x039, 0x038, 0x037, 0x035, 0x034, 0x033, 0x031, 0x030, 0x02f,
-    0x02e, 0x02d, 0x02b, 0x02a, 0x029, 0x028, 0x027, 0x026, 0x025, 0x024, 0x023, 0x022, 0x021, 0x020, 0x01f, 0x01e,
-    0x01d, 0x01c, 0x01b, 0x01a, 0x019, 0x018, 0x017, 0x017, 0x016, 0x015, 0x014, 0x014, 0x013, 0x012, 0x011, 0x011,
-    0x010, 0x00f, 0x00f, 0x00e, 0x00d, 0x00d, 0x00c, 0x00c, 0x00b, 0x00a, 0x00a, 0x009, 0x009, 0x008, 0x008, 0x007,
-    0x007, 0x007, 0x006, 0x006, 0x005, 0x005, 0x005, 0x004, 0x004, 0x004, 0x003, 0x003, 0x003, 0x002, 0x002, 0x002,
-    0x002, 0x001, 0x001, 0x001, 0x001, 0x001, 0x001, 0x001, 0x000, 0x000, 0x000, 0x000, 0x000, 0x000, 0x000, 0x000
+    0x859, 0x6c3, 0x607, 0x58b, 0x52e, 0x4e4, 0x4a6, 0x471,
+    0x443, 0x41a, 0x3f5, 0x3d3, 0x3b5, 0x398, 0x37e, 0x365,
+    0x34e, 0x339, 0x324, 0x311, 0x2ff, 0x2ed, 0x2dc, 0x2cd,
+    0x2bd, 0x2af, 0x2a0, 0x293, 0x286, 0x279, 0x26d, 0x261,
+    0x256, 0x24b, 0x240, 0x236, 0x22c, 0x222, 0x218, 0x20f,
+    0x206, 0x1fd, 0x1f5, 0x1ec, 0x1e4, 0x1dc, 0x1d4, 0x1cd,
+    0x1c5, 0x1be, 0x1b7, 0x1b0, 0x1a9, 0x1a2, 0x19b, 0x195,
+    0x18f, 0x188, 0x182, 0x17c, 0x177, 0x171, 0x16b, 0x166,
+    0x160, 0x15b, 0x155, 0x150, 0x14b, 0x146, 0x141, 0x13c,
+    0x137, 0x133, 0x12e, 0x129, 0x125, 0x121, 0x11c, 0x118,
+    0x114, 0x10f, 0x10b, 0x107, 0x103, 0x0ff, 0x0fb, 0x0f8,
+    0x0f4, 0x0f0, 0x0ec, 0x0e9, 0x0e5, 0x0e2, 0x0de, 0x0db,
+    0x0d7, 0x0d4, 0x0d1, 0x0cd, 0x0ca, 0x0c7, 0x0c4, 0x0c1,
+    0x0be, 0x0bb, 0x0b8, 0x0b5, 0x0b2, 0x0af, 0x0ac, 0x0a9,
+    0x0a7, 0x0a4, 0x0a1, 0x09f, 0x09c, 0x099, 0x097, 0x094,
+    0x092, 0x08f, 0x08d, 0x08a, 0x088, 0x086, 0x083, 0x081,
+    0x07f, 0x07d, 0x07a, 0x078, 0x076, 0x074, 0x072, 0x070,
+    0x06e, 0x06c, 0x06a, 0x068, 0x066, 0x064, 0x062, 0x060,
+    0x05e, 0x05c, 0x05b, 0x059, 0x057, 0x055, 0x053, 0x052,
+    0x050, 0x04e, 0x04d, 0x04b, 0x04a, 0x048, 0x046, 0x045,
+    0x043, 0x042, 0x040, 0x03f, 0x03e, 0x03c, 0x03b, 0x039,
+    0x038, 0x037, 0x035, 0x034, 0x033, 0x031, 0x030, 0x02f,
+    0x02e, 0x02d, 0x02b, 0x02a, 0x029, 0x028, 0x027, 0x026,
+    0x025, 0x024, 0x023, 0x022, 0x021, 0x020, 0x01f, 0x01e,
+    0x01d, 0x01c, 0x01b, 0x01a, 0x019, 0x018, 0x017, 0x017,
+    0x016, 0x015, 0x014, 0x014, 0x013, 0x012, 0x011, 0x011,
+    0x010, 0x00f, 0x00f, 0x00e, 0x00d, 0x00d, 0x00c, 0x00c,
+    0x00b, 0x00a, 0x00a, 0x009, 0x009, 0x008, 0x008, 0x007,
+    0x007, 0x007, 0x006, 0x006, 0x005, 0x005, 0x005, 0x004,
+    0x004, 0x004, 0x003, 0x003, 0x003, 0x002, 0x002, 0x002,
+    0x002, 0x001, 0x001, 0x001, 0x001, 0x001, 0x001, 0x001,
+    0x000, 0x000, 0x000, 0x000, 0x000, 0x000, 0x000, 0x000
 };
 
 //
@@ -74,439 +94,585 @@ static const Bit16u logsinrom[256] = {
 //
 
 static const Bit16u exprom[256] = {
-    0x000, 0x003, 0x006, 0x008, 0x00b, 0x00e, 0x011, 0x014, 0x016, 0x019, 0x01c, 0x01f, 0x022, 0x025, 0x028, 0x02a,
-    0x02d, 0x030, 0x033, 0x036, 0x039, 0x03c, 0x03f, 0x042, 0x045, 0x048, 0x04b, 0x04e, 0x051, 0x054, 0x057, 0x05a,
-    0x05d, 0x060, 0x063, 0x066, 0x069, 0x06c, 0x06f, 0x072, 0x075, 0x078, 0x07b, 0x07e, 0x082, 0x085, 0x088, 0x08b,
-    0x08e, 0x091, 0x094, 0x098, 0x09b, 0x09e, 0x0a1, 0x0a4, 0x0a8, 0x0ab, 0x0ae, 0x0b1, 0x0b5, 0x0b8, 0x0bb, 0x0be,
-    0x0c2, 0x0c5, 0x0c8, 0x0cc, 0x0cf, 0x0d2, 0x0d6, 0x0d9, 0x0dc, 0x0e0, 0x0e3, 0x0e7, 0x0ea, 0x0ed, 0x0f1, 0x0f4,
-    0x0f8, 0x0fb, 0x0ff, 0x102, 0x106, 0x109, 0x10c, 0x110, 0x114, 0x117, 0x11b, 0x11e, 0x122, 0x125, 0x129, 0x12c,
-    0x130, 0x134, 0x137, 0x13b, 0x13e, 0x142, 0x146, 0x149, 0x14d, 0x151, 0x154, 0x158, 0x15c, 0x160, 0x163, 0x167,
-    0x16b, 0x16f, 0x172, 0x176, 0x17a, 0x17e, 0x181, 0x185, 0x189, 0x18d, 0x191, 0x195, 0x199, 0x19c, 0x1a0, 0x1a4,
-    0x1a8, 0x1ac, 0x1b0, 0x1b4, 0x1b8, 0x1bc, 0x1c0, 0x1c4, 0x1c8, 0x1cc, 0x1d0, 0x1d4, 0x1d8, 0x1dc, 0x1e0, 0x1e4,
-    0x1e8, 0x1ec, 0x1f0, 0x1f5, 0x1f9, 0x1fd, 0x201, 0x205, 0x209, 0x20e, 0x212, 0x216, 0x21a, 0x21e, 0x223, 0x227,
-    0x22b, 0x230, 0x234, 0x238, 0x23c, 0x241, 0x245, 0x249, 0x24e, 0x252, 0x257, 0x25b, 0x25f, 0x264, 0x268, 0x26d,
-    0x271, 0x276, 0x27a, 0x27f, 0x283, 0x288, 0x28c, 0x291, 0x295, 0x29a, 0x29e, 0x2a3, 0x2a8, 0x2ac, 0x2b1, 0x2b5,
-    0x2ba, 0x2bf, 0x2c4, 0x2c8, 0x2cd, 0x2d2, 0x2d6, 0x2db, 0x2e0, 0x2e5, 0x2e9, 0x2ee, 0x2f3, 0x2f8, 0x2fd, 0x302,
-    0x306, 0x30b, 0x310, 0x315, 0x31a, 0x31f, 0x324, 0x329, 0x32e, 0x333, 0x338, 0x33d, 0x342, 0x347, 0x34c, 0x351,
-    0x356, 0x35b, 0x360, 0x365, 0x36a, 0x370, 0x375, 0x37a, 0x37f, 0x384, 0x38a, 0x38f, 0x394, 0x399, 0x39f, 0x3a4,
-    0x3a9, 0x3ae, 0x3b4, 0x3b9, 0x3bf, 0x3c4, 0x3c9, 0x3cf, 0x3d4, 0x3da, 0x3df, 0x3e4, 0x3ea, 0x3ef, 0x3f5, 0x3fa
+    0x7fa, 0x7f5, 0x7ef, 0x7ea, 0x7e4, 0x7df, 0x7da, 0x7d4,
+    0x7cf, 0x7c9, 0x7c4, 0x7bf, 0x7b9, 0x7b4, 0x7ae, 0x7a9,
+    0x7a4, 0x79f, 0x799, 0x794, 0x78f, 0x78a, 0x784, 0x77f,
+    0x77a, 0x775, 0x770, 0x76a, 0x765, 0x760, 0x75b, 0x756,
+    0x751, 0x74c, 0x747, 0x742, 0x73d, 0x738, 0x733, 0x72e,
+    0x729, 0x724, 0x71f, 0x71a, 0x715, 0x710, 0x70b, 0x706,
+    0x702, 0x6fd, 0x6f8, 0x6f3, 0x6ee, 0x6e9, 0x6e5, 0x6e0,
+    0x6db, 0x6d6, 0x6d2, 0x6cd, 0x6c8, 0x6c4, 0x6bf, 0x6ba,
+    0x6b5, 0x6b1, 0x6ac, 0x6a8, 0x6a3, 0x69e, 0x69a, 0x695,
+    0x691, 0x68c, 0x688, 0x683, 0x67f, 0x67a, 0x676, 0x671,
+    0x66d, 0x668, 0x664, 0x65f, 0x65b, 0x657, 0x652, 0x64e,
+    0x649, 0x645, 0x641, 0x63c, 0x638, 0x634, 0x630, 0x62b,
+    0x627, 0x623, 0x61e, 0x61a, 0x616, 0x612, 0x60e, 0x609,
+    0x605, 0x601, 0x5fd, 0x5f9, 0x5f5, 0x5f0, 0x5ec, 0x5e8,
+    0x5e4, 0x5e0, 0x5dc, 0x5d8, 0x5d4, 0x5d0, 0x5cc, 0x5c8,
+    0x5c4, 0x5c0, 0x5bc, 0x5b8, 0x5b4, 0x5b0, 0x5ac, 0x5a8,
+    0x5a4, 0x5a0, 0x59c, 0x599, 0x595, 0x591, 0x58d, 0x589,
+    0x585, 0x581, 0x57e, 0x57a, 0x576, 0x572, 0x56f, 0x56b,
+    0x567, 0x563, 0x560, 0x55c, 0x558, 0x554, 0x551, 0x54d,
+    0x549, 0x546, 0x542, 0x53e, 0x53b, 0x537, 0x534, 0x530,
+    0x52c, 0x529, 0x525, 0x522, 0x51e, 0x51b, 0x517, 0x514,
+    0x510, 0x50c, 0x509, 0x506, 0x502, 0x4ff, 0x4fb, 0x4f8,
+    0x4f4, 0x4f1, 0x4ed, 0x4ea, 0x4e7, 0x4e3, 0x4e0, 0x4dc,
+    0x4d9, 0x4d6, 0x4d2, 0x4cf, 0x4cc, 0x4c8, 0x4c5, 0x4c2,
+    0x4be, 0x4bb, 0x4b8, 0x4b5, 0x4b1, 0x4ae, 0x4ab, 0x4a8,
+    0x4a4, 0x4a1, 0x49e, 0x49b, 0x498, 0x494, 0x491, 0x48e,
+    0x48b, 0x488, 0x485, 0x482, 0x47e, 0x47b, 0x478, 0x475,
+    0x472, 0x46f, 0x46c, 0x469, 0x466, 0x463, 0x460, 0x45d,
+    0x45a, 0x457, 0x454, 0x451, 0x44e, 0x44b, 0x448, 0x445,
+    0x442, 0x43f, 0x43c, 0x439, 0x436, 0x433, 0x430, 0x42d,
+    0x42a, 0x428, 0x425, 0x422, 0x41f, 0x41c, 0x419, 0x416,
+    0x414, 0x411, 0x40e, 0x40b, 0x408, 0x406, 0x403, 0x400
 };
 
-// 
+//
 // freq mult table multiplied by 2
 //
 // 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 12, 12, 15, 15
 //
 
-static const Bit8u mt[16] = { 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 20, 24, 24, 30, 30 };
+static const Bit8u mt[16] = {
+    1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 20, 24, 24, 30, 30
+};
 
 //
 // ksl table
 //
 
-static const Bit8u kslrom[16] = { 0, 32, 40, 45, 48, 51, 53, 55, 56, 58, 59, 60, 61, 62, 63, 64 };
+static const Bit8u kslrom[16] = {
+    0, 32, 40, 45, 48, 51, 53, 55, 56, 58, 59, 60, 61, 62, 63, 64
+};
 
-static const Bit8u kslshift[4] = { 8, 1, 2, 0 };
-
-//
-// LFO vibrato
-//
-
-static const Bit8u vib_table[8] = { 3, 1, 0, 1, 3, 1, 0, 1 };
-static const Bit8s vibsgn_table[8] = { 1, 1, 1, 1, -1, -1, -1, -1 };
+static const Bit8u kslshift[4] = {
+    8, 1, 2, 0
+};
 
 //
 // envelope generator constants
 //
 
-static const Bit8u eg_incstep[3][4][8] = {
-    { { 0, 0, 0, 0, 0, 0, 0, 0 },{ 0, 0, 0, 0, 0, 0, 0, 0 },{ 0, 0, 0, 0, 0, 0, 0, 0 },{ 0, 0, 0, 0, 0, 0, 0, 0 } },
-    { { 0, 1, 0, 1, 0, 1, 0, 1 },{ 0, 1, 0, 1, 1, 1, 0, 1 },{ 0, 1, 1, 1, 0, 1, 1, 1 },{ 0, 1, 1, 1, 1, 1, 1, 1 } },
-    { { 1, 1, 1, 1, 1, 1, 1, 1 },{ 2, 2, 1, 1, 1, 1, 1, 1 },{ 2, 2, 1, 1, 2, 2, 1, 1 },{ 2, 2, 2, 2, 2, 2, 1, 1 } }
-};
-
-static const Bit8u eg_incdesc[16] = {
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2
-};
-
-static const Bit8s eg_incsh[16] = {
-    0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, -1, -2
+static const Bit8u eg_incstep[4][4] = {
+    { 0, 0, 0, 0 },
+    { 1, 0, 0, 0 },
+    { 1, 0, 1, 0 },
+    { 1, 1, 1, 0 }
 };
 
 //
 // address decoding
 //
 
-static const Bit8s ad_slot[0x20] = { 0, 1, 2, 3, 4, 5, -1, -1, 6, 7, 8, 9, 10, 11, -1, -1, 12, 13, 14, 15, 16, 17, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
-static const Bit8u ch_slot[18] = { 0, 1, 2, 6, 7, 8, 12, 13, 14, 18, 19, 20, 24, 25, 26, 30, 31, 32 };
+static const Bit8s ad_slot[0x20] = {
+    0, 1, 2, 3, 4, 5, -1, -1, 6, 7, 8, 9, 10, 11, -1, -1,
+    12, 13, 14, 15, 16, 17, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+};
+
+static const Bit8u ch_slot[18] = {
+    0, 1, 2, 6, 7, 8, 12, 13, 14, 18, 19, 20, 24, 25, 26, 30, 31, 32
+};
 
 //
 // Envelope generator
 //
 
 typedef Bit16s(*envelope_sinfunc)(Bit16u phase, Bit16u envelope);
-typedef void(*envelope_genfunc)(opl_slot *slott);
+typedef void(*envelope_genfunc)(opl3_slot *slott);
 
-Bit16s envelope_calcexp(Bit32u level) {
-    if (level > 0x1fff) {
+static Bit16s OPL3_EnvelopeCalcExp(Bit32u level)
+{
+    if (level > 0x1fff)
+    {
         level = 0x1fff;
     }
-    return ((exprom[(level & 0xff) ^ 0xff] | 0x400) << 1) >> (level >> 8);
+    return (exprom[level & 0xff] << 1) >> (level >> 8);
 }
 
-Bit16s envelope_calcsin0(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
+{
     Bit16u out = 0;
     Bit16u neg = 0;
     phase &= 0x3ff;
-    if (phase & 0x200) {
-        neg = ~0;
+    if (phase & 0x200)
+    {
+        neg = 0xffff;
     }
-    if (phase & 0x100) {
+    if (phase & 0x100)
+    {
         out = logsinrom[(phase & 0xff) ^ 0xff];
     }
-    else {
+    else
+    {
         out = logsinrom[phase & 0xff];
     }
-    return envelope_calcexp(out + (envelope << 3)) ^ neg;
+    return OPL3_EnvelopeCalcExp(out + (envelope << 3)) ^ neg;
 }
 
-Bit16s envelope_calcsin1(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin1(Bit16u phase, Bit16u envelope)
+{
     Bit16u out = 0;
     phase &= 0x3ff;
-    if (phase & 0x200) {
+    if (phase & 0x200)
+    {
         out = 0x1000;
     }
-    else if (phase & 0x100) {
+    else if (phase & 0x100)
+    {
         out = logsinrom[(phase & 0xff) ^ 0xff];
     }
-    else {
+    else
+    {
         out = logsinrom[phase & 0xff];
     }
-    return envelope_calcexp(out + (envelope << 3));
+    return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-Bit16s envelope_calcsin2(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin2(Bit16u phase, Bit16u envelope)
+{
     Bit16u out = 0;
     phase &= 0x3ff;
-    if (phase & 0x100) {
+    if (phase & 0x100)
+    {
         out = logsinrom[(phase & 0xff) ^ 0xff];
     }
-    else {
+    else
+    {
         out = logsinrom[phase & 0xff];
     }
-    return envelope_calcexp(out + (envelope << 3));
+    return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-Bit16s envelope_calcsin3(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin3(Bit16u phase, Bit16u envelope)
+{
     Bit16u out = 0;
     phase &= 0x3ff;
-    if (phase & 0x100) {
+    if (phase & 0x100)
+    {
         out = 0x1000;
     }
-    else {
+    else
+    {
         out = logsinrom[phase & 0xff];
     }
-    return envelope_calcexp(out + (envelope << 3));
+    return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-Bit16s envelope_calcsin4(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin4(Bit16u phase, Bit16u envelope)
+{
     Bit16u out = 0;
     Bit16u neg = 0;
     phase &= 0x3ff;
-    if ((phase & 0x300) == 0x100) {
-        neg = ~0;
+    if ((phase & 0x300) == 0x100)
+    {
+        neg = 0xffff;
     }
-    if (phase & 0x200) {
+    if (phase & 0x200)
+    {
         out = 0x1000;
     }
-    else if (phase & 0x80) {
+    else if (phase & 0x80)
+    {
         out = logsinrom[((phase ^ 0xff) << 1) & 0xff];
     }
-    else {
+    else
+    {
         out = logsinrom[(phase << 1) & 0xff];
     }
-    return envelope_calcexp(out + (envelope << 3)) ^ neg;
+    return OPL3_EnvelopeCalcExp(out + (envelope << 3)) ^ neg;
 }
 
-Bit16s envelope_calcsin5(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin5(Bit16u phase, Bit16u envelope)
+{
     Bit16u out = 0;
     phase &= 0x3ff;
-    if (phase & 0x200) {
+    if (phase & 0x200)
+    {
         out = 0x1000;
     }
-    else if (phase & 0x80) {
+    else if (phase & 0x80)
+    {
         out = logsinrom[((phase ^ 0xff) << 1) & 0xff];
     }
-    else {
+    else
+    {
         out = logsinrom[(phase << 1) & 0xff];
     }
-    return envelope_calcexp(out + (envelope << 3));
+    return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-Bit16s envelope_calcsin6(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin6(Bit16u phase, Bit16u envelope)
+{
     Bit16u neg = 0;
     phase &= 0x3ff;
-    if (phase & 0x200) {
-        neg = ~0;
+    if (phase & 0x200)
+    {
+        neg = 0xffff;
     }
-    return envelope_calcexp(envelope << 3) ^ neg;
+    return OPL3_EnvelopeCalcExp(envelope << 3) ^ neg;
 }
 
-Bit16s envelope_calcsin7(Bit16u phase, Bit16u envelope) {
+static Bit16s OPL3_EnvelopeCalcSin7(Bit16u phase, Bit16u envelope)
+{
     Bit16u out = 0;
     Bit16u neg = 0;
     phase &= 0x3ff;
-    if (phase & 0x200) {
-        neg = ~0;
+    if (phase & 0x200)
+    {
+        neg = 0xffff;
         phase = (phase & 0x1ff) ^ 0x1ff;
     }
     out = phase << 3;
-    return envelope_calcexp(out + (envelope << 3)) ^ neg;
+    return OPL3_EnvelopeCalcExp(out + (envelope << 3)) ^ neg;
 }
 
-envelope_sinfunc envelope_sin[8] = {
-    envelope_calcsin0,
-    envelope_calcsin1,
-    envelope_calcsin2,
-    envelope_calcsin3,
-    envelope_calcsin4,
-    envelope_calcsin5,
-    envelope_calcsin6,
-    envelope_calcsin7
+static const envelope_sinfunc envelope_sin[8] = {
+    OPL3_EnvelopeCalcSin0,
+    OPL3_EnvelopeCalcSin1,
+    OPL3_EnvelopeCalcSin2,
+    OPL3_EnvelopeCalcSin3,
+    OPL3_EnvelopeCalcSin4,
+    OPL3_EnvelopeCalcSin5,
+    OPL3_EnvelopeCalcSin6,
+    OPL3_EnvelopeCalcSin7
 };
 
-void envelope_gen_off(opl_slot *slott);
-void envelope_gen_attack(opl_slot *slott);
-void envelope_gen_decay(opl_slot *slott);
-void envelope_gen_sustain(opl_slot *slott);
-void envelope_gen_release(opl_slot *slott);
-
-envelope_genfunc envelope_gen[5] = {
-    envelope_gen_off,
-    envelope_gen_attack,
-    envelope_gen_decay,
-    envelope_gen_sustain,
-    envelope_gen_release
+enum envelope_gen_num
+{
+    envelope_gen_num_attack = 0,
+    envelope_gen_num_decay = 1,
+    envelope_gen_num_sustain = 2,
+    envelope_gen_num_release = 3
 };
 
-enum envelope_gen_num {
-    envelope_gen_num_off = 0,
-    envelope_gen_num_attack = 1,
-    envelope_gen_num_decay = 2,
-    envelope_gen_num_sustain = 3,
-    envelope_gen_num_release = 4
-};
-
-Bit8u envelope_calc_rate(opl_slot *slot, Bit8u reg_rate) {
-    Bit8u rate;
-    if (reg_rate == 0x00) {
-        return 0x00;
-    }
-    rate = (reg_rate << 2) + (slot->reg_ksr ? slot->channel->ksv : (slot->channel->ksv >> 2));
-    if (rate > 0x3c) {
-        rate = 0x3c;
-    }
-    return rate;
-}
-
-void envelope_update_ksl(opl_slot *slot) {
-    Bit16s ksl = (kslrom[slot->channel->f_num >> 6] << 2) - ((0x08 - slot->channel->block) << 5);
-    if (ksl < 0) {
+static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
+{
+    Bit16s ksl = (kslrom[slot->channel->f_num >> 6] << 2)
+               - ((0x08 - slot->channel->block) << 5);
+    if (ksl < 0)
+    {
         ksl = 0;
     }
     slot->eg_ksl = (Bit8u)ksl;
 }
 
-void envelope_update_rate(opl_slot *slot) {
-    switch (slot->eg_gen) {
-    case envelope_gen_num_off:
-        slot->eg_rate = 0;
-        break;
+static void OPL3_EnvelopeCalc(opl3_slot *slot)
+{
+    Bit8u nonzero;
+    Bit8u rate;
+    Bit8u rate_hi;
+    Bit8u rate_lo;
+    Bit8u reg_rate = 0;
+    Bit8u ks;
+    Bit8u eg_shift, shift;
+    Bit16u eg_rout;
+    Bit16s eg_inc;
+    Bit8u eg_off;
+    Bit8u reset = 0;
+    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
+                 + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
+    if (slot->key && slot->eg_gen == envelope_gen_num_release)
+    {
+        reset = 1;
+        reg_rate = slot->reg_ar;
+    }
+    else
+    {
+        switch (slot->eg_gen)
+        {
+        case envelope_gen_num_attack:
+            reg_rate = slot->reg_ar;
+            break;
+        case envelope_gen_num_decay:
+            reg_rate = slot->reg_dr;
+            break;
+        case envelope_gen_num_sustain:
+            if (!slot->reg_type)
+            {
+                reg_rate = slot->reg_rr;
+            }
+            break;
+        case envelope_gen_num_release:
+            reg_rate = slot->reg_rr;
+            break;
+        }
+    }
+    slot->pg_reset = reset;
+    ks = slot->channel->ksv >> ((slot->reg_ksr ^ 1) << 1);
+    nonzero = (reg_rate != 0);
+    rate = ks + (reg_rate << 2);
+    rate_hi = rate >> 2;
+    rate_lo = rate & 0x03;
+    if (rate_hi & 0x10)
+    {
+        rate_hi = 0x0f;
+    }
+    eg_shift = rate_hi + slot->chip->eg_add;
+    shift = 0;
+    if (nonzero)
+    {
+        if (rate_hi < 12)
+        {
+            if (slot->chip->eg_state)
+            {
+                switch (eg_shift)
+                {
+                case 12:
+                    shift = 1;
+                    break;
+                case 13:
+                    shift = (rate_lo >> 1) & 0x01;
+                    break;
+                case 14:
+                    shift = rate_lo & 0x01;
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+        else
+        {
+            shift = (rate_hi & 0x03) + eg_incstep[rate_lo][slot->chip->timer & 0x03];
+            if (shift & 0x04)
+            {
+                shift = 0x03;
+            }
+            if (!shift)
+            {
+                shift = slot->chip->eg_state;
+            }
+        }
+    }
+    eg_rout = slot->eg_rout;
+    eg_inc = 0;
+    eg_off = 0;
+    // Instant attack
+    if (reset && rate_hi == 0x0f)
+    {
+        eg_rout = 0x00;
+    }
+    // Envelope off
+    if ((slot->eg_rout & 0x1f8) == 0x1f8)
+    {
+        eg_off = 1;
+    }
+    if (slot->eg_gen != envelope_gen_num_attack && !reset && eg_off)
+    {
+        eg_rout = 0x1ff;
+    }
+    switch (slot->eg_gen)
+    {
     case envelope_gen_num_attack:
-        slot->eg_rate = envelope_calc_rate(slot, slot->reg_ar);
+        if (!slot->eg_rout)
+        {
+            slot->eg_gen = envelope_gen_num_decay;
+        }
+        else if (slot->key && shift > 0 && rate_hi != 0x0f)
+        {
+            eg_inc = ((~slot->eg_rout) << shift) >> 4;
+        }
         break;
     case envelope_gen_num_decay:
-        slot->eg_rate = envelope_calc_rate(slot, slot->reg_dr);
+        if ((slot->eg_rout >> 4) == slot->reg_sl)
+        {
+            slot->eg_gen = envelope_gen_num_sustain;
+        }
+        else if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
         break;
     case envelope_gen_num_sustain:
     case envelope_gen_num_release:
-        slot->eg_rate = envelope_calc_rate(slot, slot->reg_rr);
+        if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
         break;
     }
-}
-
-void envelope_gen_off(opl_slot *slot) {
-    slot->eg_rout = 0x1ff;
-}
-
-void envelope_gen_attack(opl_slot *slot) {
-    if (slot->eg_rout == 0x00) {
-        slot->eg_gen = envelope_gen_num_decay;
-        envelope_update_rate(slot);
-        return;
-    }
-    slot->eg_rout += ((~slot->eg_rout) * slot->eg_inc) >> 3;
-    if (slot->eg_rout < 0x00) {
-        slot->eg_rout = 0x00;
-    }
-}
-
-void envelope_gen_decay(opl_slot *slot) {
-    if (slot->eg_rout >= slot->reg_sl << 4) {
-        slot->eg_gen = envelope_gen_num_sustain;
-        envelope_update_rate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
-void envelope_gen_sustain(opl_slot *slot) {
-    if (!slot->reg_type) {
-        envelope_gen_release(slot);
-    }
-}
-
-void envelope_gen_release(opl_slot *slot) {
-    if (slot->eg_rout >= 0x1ff) {
-        slot->eg_gen = envelope_gen_num_off;
-        slot->eg_rout = 0x1ff;
-        envelope_update_rate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
-void envelope_calc(opl_slot *slot) {
-    Bit8u rate_h, rate_l;
-    Bit8u inc = 0;
-    rate_h = slot->eg_rate >> 2;
-    rate_l = slot->eg_rate & 3;
-    if (eg_incsh[rate_h] > 0) {
-        if ((slot->chip->timer & ((1 << eg_incsh[rate_h]) - 1)) == 0) {
-            inc = eg_incstep[eg_incdesc[rate_h]][rate_l][((slot->chip->timer) >> eg_incsh[rate_h]) & 0x07];
-        }
-    }
-    else {
-        inc = eg_incstep[eg_incdesc[rate_h]][rate_l][slot->chip->timer & 0x07] << (-eg_incsh[rate_h]);
-    }
-    slot->eg_inc = inc;
-    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2) + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
-    envelope_gen[slot->eg_gen](slot);
-}
-
-void eg_keyon(opl_slot *slot, Bit8u type) {
-    if (!slot->key) {
+    slot->eg_rout = (eg_rout + eg_inc) & 0x1ff;
+    // Key off
+    if (reset)
+    {
         slot->eg_gen = envelope_gen_num_attack;
-        envelope_update_rate(slot);
-        if ((slot->eg_rate >> 2) == 0x0f) {
-            slot->eg_gen = envelope_gen_num_decay;
-            envelope_update_rate(slot);
-            slot->eg_rout = 0x00;
-        }
-        slot->pg_phase = 0x00;
     }
+    if (!slot->key)
+    {
+        slot->eg_gen = envelope_gen_num_release;
+    }
+}
+
+static void OPL3_EnvelopeKeyOn(opl3_slot *slot, Bit8u type)
+{
     slot->key |= type;
 }
 
-void eg_keyoff(opl_slot *slot, Bit8u type) {
-    if (slot->key) {
-        slot->key &= (~type);
-        if (!slot->key) {
-            slot->eg_gen = envelope_gen_num_release;
-            envelope_update_rate(slot);
-        }
-    }
+static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
+{
+    slot->key &= ~type;
 }
 
 //
 // Phase Generator
 //
 
-void pg_generate(opl_slot *slot) {
-    Bit8u f_num_high;
-    Bit16u f_num = slot->channel->f_num;
+static void OPL3_PhaseGenerate(opl3_slot *slot)
+{
+    opl3_chip *chip;
+    Bit16u f_num;
+    Bit32u basefreq;
+    Bit8u rm_xor, n_bit;
+    Bit32u noise;
+    Bit16u phase;
 
-    if (slot->reg_vib) {
-        f_num_high = f_num >> (7 + vib_table[(slot->chip->timer >> 10) & 0x07] + (0x01 - slot->chip->dvb));
-        f_num += f_num_high * vibsgn_table[(slot->chip->timer >> 10) & 0x07];
+    chip = slot->chip;
+    f_num = slot->channel->f_num;
+    if (slot->reg_vib)
+    {
+        Bit8s range;
+        Bit8u vibpos;
+
+        range = (f_num >> 7) & 7;
+        vibpos = slot->chip->vibpos;
+
+        if (!(vibpos & 3))
+        {
+            range = 0;
+        }
+        else if (vibpos & 1)
+        {
+            range >>= 1;
+        }
+        range >>= slot->chip->vibshift;
+
+        if (vibpos & 4)
+        {
+            range = -range;
+        }
+        f_num += range;
     }
-    slot->pg_phase += (((f_num << slot->channel->block) >> 1) * mt[slot->reg_mult]) >> 1;
-}
-
-//
-// Noise Generator
-//
-
-void n_generate(opl_chip *chip) {
-    if (chip->noise & 0x01) {
-        chip->noise ^= 0x800302;
+    basefreq = (f_num << slot->channel->block) >> 1;
+    phase = (Bit16u)(slot->pg_phase >> 9);
+    if (slot->pg_reset)
+    {
+        slot->pg_phase = 0;
     }
-    chip->noise >>= 1;
+    slot->pg_phase += (basefreq * mt[slot->reg_mult]) >> 1;
+    // Rhythm mode
+    noise = chip->noise;
+    slot->pg_phase_out = phase;
+    if (slot->slot_num == 13) // hh
+    {
+        chip->rm_hh_bit2 = (phase >> 2) & 1;
+        chip->rm_hh_bit3 = (phase >> 3) & 1;
+        chip->rm_hh_bit7 = (phase >> 7) & 1;
+        chip->rm_hh_bit8 = (phase >> 8) & 1;
+    }
+    if (slot->slot_num == 17 && (chip->rhy & 0x20)) // tc
+    {
+        chip->rm_tc_bit3 = (phase >> 3) & 1;
+        chip->rm_tc_bit5 = (phase >> 5) & 1;
+    }
+    if (chip->rhy & 0x20)
+    {
+        rm_xor = (chip->rm_hh_bit2 ^ chip->rm_hh_bit7)
+               | (chip->rm_hh_bit3 ^ chip->rm_tc_bit5)
+               | (chip->rm_tc_bit3 ^ chip->rm_tc_bit5);
+        switch (slot->slot_num)
+        {
+        case 13: // hh
+            slot->pg_phase_out = rm_xor << 9;
+            if (rm_xor ^ (noise & 1))
+            {
+                slot->pg_phase_out |= 0xd0;
+            }
+            else
+            {
+                slot->pg_phase_out |= 0x34;
+            }
+            break;
+        case 16: // sd
+            slot->pg_phase_out = (chip->rm_hh_bit8 << 9)
+                               | ((chip->rm_hh_bit8 ^ (noise & 1)) << 8);
+            break;
+        case 17: // tc
+            slot->pg_phase_out = (rm_xor << 9) | 0x80;
+            break;
+        default:
+            break;
+        }
+    }
+    n_bit = ((noise >> 14) ^ noise) & 0x01;
+    chip->noise = (noise >> 1) | (n_bit << 22);
 }
 
 //
 // Slot
 //
 
-void slot_write20(opl_slot *slot, Bit8u data) {
-    if ((data >> 7) & 0x01) {
-        slot->trem = &slot->chip->tremval;
+static void OPL3_SlotWrite20(opl3_slot *slot, Bit8u data)
+{
+    if ((data >> 7) & 0x01)
+    {
+        slot->trem = &slot->chip->tremolo;
     }
-    else {
+    else
+    {
         slot->trem = (Bit8u*)&slot->chip->zeromod;
     }
     slot->reg_vib = (data >> 6) & 0x01;
     slot->reg_type = (data >> 5) & 0x01;
     slot->reg_ksr = (data >> 4) & 0x01;
     slot->reg_mult = data & 0x0f;
-    envelope_update_rate(slot);
 }
 
-void slot_write40(opl_slot *slot, Bit8u data) {
+static void OPL3_SlotWrite40(opl3_slot *slot, Bit8u data)
+{
     slot->reg_ksl = (data >> 6) & 0x03;
     slot->reg_tl = data & 0x3f;
-    envelope_update_ksl(slot);
+    OPL3_EnvelopeUpdateKSL(slot);
 }
 
-void slot_write60(opl_slot *slot, Bit8u data) {
+static void OPL3_SlotWrite60(opl3_slot *slot, Bit8u data)
+{
     slot->reg_ar = (data >> 4) & 0x0f;
     slot->reg_dr = data & 0x0f;
-    envelope_update_rate(slot);
 }
 
-void slot_write80(opl_slot *slot, Bit8u data) {
+static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
+{
     slot->reg_sl = (data >> 4) & 0x0f;
-    if (slot->reg_sl == 0x0f) {
+    if (slot->reg_sl == 0x0f)
+    {
         slot->reg_sl = 0x1f;
     }
     slot->reg_rr = data & 0x0f;
-    envelope_update_rate(slot);
 }
 
-void slot_writee0(opl_slot *slot, Bit8u data) {
+static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
+{
     slot->reg_wf = data & 0x07;
-    if (slot->chip->newm == 0x00) {
+    if (slot->chip->newm == 0x00)
+    {
         slot->reg_wf &= 0x03;
     }
 }
 
-void slot_generatephase(opl_slot *slot, Bit16u phase) {
-    slot->out = envelope_sin[slot->reg_wf](phase, slot->eg_out);
+static void OPL3_SlotGenerate(opl3_slot *slot)
+{
+    slot->out = envelope_sin[slot->reg_wf](slot->pg_phase_out + *slot->mod, slot->eg_out);
 }
 
-void slot_generate(opl_slot *slot) {
-    slot_generatephase(slot, (Bit16u)(slot->pg_phase >> 9) + *slot->mod);
-}
-
-void slot_generatezm(opl_slot *slot) {
-    slot_generatephase(slot, 0);
-}
-
-void slot_calcfb(opl_slot *slot) {
-    if (slot->channel->fb != 0x00) {
+static void OPL3_SlotCalcFB(opl3_slot *slot)
+{
+    if (slot->channel->fb != 0x00)
+    {
         slot->fbmod = (slot->prout + slot->out) >> (0x09 - slot->channel->fb);
     }
-    else {
+    else
+    {
         slot->fbmod = 0;
     }
     slot->prout = slot->out;
@@ -516,16 +682,18 @@ void slot_calcfb(opl_slot *slot) {
 // Channel
 //
 
-void chan_setupalg(opl_channel *channel);
+static void OPL3_ChannelSetupAlg(opl3_channel *channel);
 
-void chan_updaterhythm(opl_chip *chip, Bit8u data) {
-    opl_channel *channel6;
-    opl_channel *channel7;
-    opl_channel *channel8;
+static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
+{
+    opl3_channel *channel6;
+    opl3_channel *channel7;
+    opl3_channel *channel8;
     Bit8u chnum;
 
     chip->rhy = data & 0x3f;
-    if (chip->rhy & 0x20) {
+    if (chip->rhy & 0x20)
+    {
         channel6 = &chip->channel[6];
         channel7 = &chip->channel[7];
         channel8 = &chip->channel[8];
@@ -541,101 +709,127 @@ void chan_updaterhythm(opl_chip *chip, Bit8u data) {
         channel8->out[1] = &channel8->slots[0]->out;
         channel8->out[2] = &channel8->slots[1]->out;
         channel8->out[3] = &channel8->slots[1]->out;
-        for (chnum = 6; chnum < 9; chnum++) {
+        for (chnum = 6; chnum < 9; chnum++)
+        {
             chip->channel[chnum].chtype = ch_drum;
         }
-        chan_setupalg(channel6);
+        OPL3_ChannelSetupAlg(channel6);
+        OPL3_ChannelSetupAlg(channel7);
+        OPL3_ChannelSetupAlg(channel8);
         //hh
-        if (chip->rhy & 0x01) {
-            eg_keyon(channel7->slots[0], egk_drum);
+        if (chip->rhy & 0x01)
+        {
+            OPL3_EnvelopeKeyOn(channel7->slots[0], egk_drum);
         }
-        else {
-            eg_keyoff(channel7->slots[0], egk_drum);
+        else
+        {
+            OPL3_EnvelopeKeyOff(channel7->slots[0], egk_drum);
         }
         //tc
-        if (chip->rhy & 0x02) {
-            eg_keyon(channel8->slots[1], egk_drum);
+        if (chip->rhy & 0x02)
+        {
+            OPL3_EnvelopeKeyOn(channel8->slots[1], egk_drum);
         }
-        else {
-            eg_keyoff(channel8->slots[1], egk_drum);
+        else
+        {
+            OPL3_EnvelopeKeyOff(channel8->slots[1], egk_drum);
         }
         //tom
-        if (chip->rhy & 0x04) {
-            eg_keyon(channel8->slots[0], egk_drum);
+        if (chip->rhy & 0x04)
+        {
+            OPL3_EnvelopeKeyOn(channel8->slots[0], egk_drum);
         }
-        else {
-            eg_keyoff(channel8->slots[0], egk_drum);
+        else
+        {
+            OPL3_EnvelopeKeyOff(channel8->slots[0], egk_drum);
         }
         //sd
-        if (chip->rhy & 0x08) {
-            eg_keyon(channel7->slots[1], egk_drum);
+        if (chip->rhy & 0x08)
+        {
+            OPL3_EnvelopeKeyOn(channel7->slots[1], egk_drum);
         }
-        else {
-            eg_keyoff(channel7->slots[1], egk_drum);
+        else
+        {
+            OPL3_EnvelopeKeyOff(channel7->slots[1], egk_drum);
         }
         //bd
-        if (chip->rhy & 0x10) {
-            eg_keyon(channel6->slots[0], egk_drum);
-            eg_keyon(channel6->slots[1], egk_drum);
+        if (chip->rhy & 0x10)
+        {
+            OPL3_EnvelopeKeyOn(channel6->slots[0], egk_drum);
+            OPL3_EnvelopeKeyOn(channel6->slots[1], egk_drum);
         }
-        else {
-            eg_keyoff(channel6->slots[0], egk_drum);
-            eg_keyoff(channel6->slots[1], egk_drum);
+        else
+        {
+            OPL3_EnvelopeKeyOff(channel6->slots[0], egk_drum);
+            OPL3_EnvelopeKeyOff(channel6->slots[1], egk_drum);
         }
     }
-    else {
-        for (chnum = 6; chnum < 9; chnum++) {
+    else
+    {
+        for (chnum = 6; chnum < 9; chnum++)
+        {
             chip->channel[chnum].chtype = ch_2op;
-            chan_setupalg(&chip->channel[chnum]);
+            OPL3_ChannelSetupAlg(&chip->channel[chnum]);
+            OPL3_EnvelopeKeyOff(chip->channel[chnum].slots[0], egk_drum);
+            OPL3_EnvelopeKeyOff(chip->channel[chnum].slots[1], egk_drum);
         }
     }
 }
 
-void chan_writea0(opl_channel *channel, Bit8u data) {
-    if (channel->chip->newm && channel->chtype == ch_4op2) {
+static void OPL3_ChannelWriteA0(opl3_channel *channel, Bit8u data)
+{
+    if (channel->chip->newm && channel->chtype == ch_4op2)
+    {
         return;
     }
     channel->f_num = (channel->f_num & 0x300) | data;
-    channel->ksv = (channel->block << 1) | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
-    envelope_update_ksl(channel->slots[0]);
-    envelope_update_ksl(channel->slots[1]);
-    envelope_update_rate(channel->slots[0]);
-    envelope_update_rate(channel->slots[1]);
-    if (channel->chip->newm && channel->chtype == ch_4op) {
+    channel->ksv = (channel->block << 1)
+                 | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
+    OPL3_EnvelopeUpdateKSL(channel->slots[0]);
+    OPL3_EnvelopeUpdateKSL(channel->slots[1]);
+    if (channel->chip->newm && channel->chtype == ch_4op)
+    {
         channel->pair->f_num = channel->f_num;
         channel->pair->ksv = channel->ksv;
-        envelope_update_ksl(channel->pair->slots[0]);
-        envelope_update_ksl(channel->pair->slots[1]);
-        envelope_update_rate(channel->pair->slots[0]);
-        envelope_update_rate(channel->pair->slots[1]);
+        OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
+        OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
     }
 }
 
-void chan_writeb0(opl_channel *channel, Bit8u data) {
-    if (channel->chip->newm && channel->chtype == ch_4op2) {
+static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
+{
+    if (channel->chip->newm && channel->chtype == ch_4op2)
+    {
         return;
     }
     channel->f_num = (channel->f_num & 0xff) | ((data & 0x03) << 8);
     channel->block = (data >> 2) & 0x07;
-    channel->ksv = (channel->block << 1) | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
-    envelope_update_ksl(channel->slots[0]);
-    envelope_update_ksl(channel->slots[1]);
-    envelope_update_rate(channel->slots[0]);
-    envelope_update_rate(channel->slots[1]);
-    if (channel->chip->newm && channel->chtype == ch_4op) {
+    channel->ksv = (channel->block << 1)
+                 | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
+    OPL3_EnvelopeUpdateKSL(channel->slots[0]);
+    OPL3_EnvelopeUpdateKSL(channel->slots[1]);
+    if (channel->chip->newm && channel->chtype == ch_4op)
+    {
         channel->pair->f_num = channel->f_num;
         channel->pair->block = channel->block;
         channel->pair->ksv = channel->ksv;
-        envelope_update_ksl(channel->pair->slots[0]);
-        envelope_update_ksl(channel->pair->slots[1]);
-        envelope_update_rate(channel->pair->slots[0]);
-        envelope_update_rate(channel->pair->slots[1]);
+        OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
+        OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
     }
 }
 
-void chan_setupalg(opl_channel *channel) {
-    if (channel->chtype == ch_drum) {
-        switch (channel->alg & 0x01) {
+static void OPL3_ChannelSetupAlg(opl3_channel *channel)
+{
+    if (channel->chtype == ch_drum)
+    {
+        if (channel->ch_num == 7 || channel->ch_num == 8)
+        {
+            channel->slots[0]->mod = &channel->chip->zeromod;
+            channel->slots[1]->mod = &channel->chip->zeromod;
+            return;
+        }
+        switch (channel->alg & 0x01)
+        {
         case 0x00:
             channel->slots[0]->mod = &channel->slots[0]->fbmod;
             channel->slots[1]->mod = &channel->slots[0]->out;
@@ -647,15 +841,18 @@ void chan_setupalg(opl_channel *channel) {
         }
         return;
     }
-    if (channel->alg & 0x08) {
+    if (channel->alg & 0x08)
+    {
         return;
     }
-    if (channel->alg & 0x04) {
+    if (channel->alg & 0x04)
+    {
         channel->pair->out[0] = &channel->chip->zeromod;
         channel->pair->out[1] = &channel->chip->zeromod;
         channel->pair->out[2] = &channel->chip->zeromod;
         channel->pair->out[3] = &channel->chip->zeromod;
-        switch (channel->alg & 0x03) {
+        switch (channel->alg & 0x03)
+        {
         case 0x00:
             channel->pair->slots[0]->mod = &channel->pair->slots[0]->fbmod;
             channel->pair->slots[1]->mod = &channel->pair->slots[0]->out;
@@ -698,8 +895,10 @@ void chan_setupalg(opl_channel *channel) {
             break;
         }
     }
-    else {
-        switch (channel->alg & 0x01) {
+    else
+    {
+        switch (channel->alg & 0x01)
+        {
         case 0x00:
             channel->slots[0]->mod = &channel->slots[0]->fbmod;
             channel->slots[1]->mod = &channel->slots[0]->out;
@@ -720,296 +919,306 @@ void chan_setupalg(opl_channel *channel) {
     }
 }
 
-void chan_writec0(opl_channel *channel, Bit8u data) {
+static void OPL3_ChannelWriteC0(opl3_channel *channel, Bit8u data)
+{
     channel->fb = (data & 0x0e) >> 1;
     channel->con = data & 0x01;
     channel->alg = channel->con;
-    if (channel->chip->newm) {
-        if (channel->chtype == ch_4op) {
+    if (channel->chip->newm)
+    {
+        if (channel->chtype == ch_4op)
+        {
             channel->pair->alg = 0x04 | (channel->con << 1) | (channel->pair->con);
             channel->alg = 0x08;
-            chan_setupalg(channel->pair);
+            OPL3_ChannelSetupAlg(channel->pair);
         }
-        else if (channel->chtype == ch_4op2) {
+        else if (channel->chtype == ch_4op2)
+        {
             channel->alg = 0x04 | (channel->pair->con << 1) | (channel->con);
             channel->pair->alg = 0x08;
-            chan_setupalg(channel);
+            OPL3_ChannelSetupAlg(channel);
         }
-        else {
-            chan_setupalg(channel);
+        else
+        {
+            OPL3_ChannelSetupAlg(channel);
         }
     }
-    else {
-        chan_setupalg(channel);
+    else
+    {
+        OPL3_ChannelSetupAlg(channel);
     }
-    if (channel->chip->newm) {
+    if (channel->chip->newm)
+    {
         channel->cha = ((data >> 4) & 0x01) ? ~0 : 0;
         channel->chb = ((data >> 5) & 0x01) ? ~0 : 0;
     }
-    else {
-        channel->cha = channel->chb = ~0;
+    else
+    {
+        channel->cha = channel->chb = (Bit16u)~0;
     }
 }
 
-void chan_generaterhythm1(opl_chip *chip) {
-    opl_channel *channel6;
-    opl_channel *channel7;
-    opl_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    slot_generate(channel6->slots[0]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04) | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //hh
-    phase = (phasebit << 9) | (0x34 << ((phasebit ^ (chip->noise & 0x01) << 1)));
-    slot_generatephase(channel7->slots[0], phase);
-    //tt
-    slot_generatezm(channel8->slots[0]);
-}
-
-void chan_generaterhythm2(opl_chip *chip) {
-    opl_channel *channel6;
-    opl_channel *channel7;
-    opl_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    slot_generate(channel6->slots[1]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04) | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //sd
-    phase = (0x100 << ((phase14 >> 8) & 0x01)) ^ ((chip->noise & 0x01) << 8);
-    slot_generatephase(channel7->slots[1], phase);
-    //tc
-    phase = 0x100 | (phasebit << 9);
-    slot_generatephase(channel8->slots[1], phase);
-}
-
-void chan_enable(opl_channel *channel) {
-    if (channel->chip->newm) {
-        if (channel->chtype == ch_4op) {
-            eg_keyon(channel->slots[0], egk_norm);
-            eg_keyon(channel->slots[1], egk_norm);
-            eg_keyon(channel->pair->slots[0], egk_norm);
-            eg_keyon(channel->pair->slots[1], egk_norm);
+static void OPL3_ChannelKeyOn(opl3_channel *channel)
+{
+    if (channel->chip->newm)
+    {
+        if (channel->chtype == ch_4op)
+        {
+            OPL3_EnvelopeKeyOn(channel->slots[0], egk_norm);
+            OPL3_EnvelopeKeyOn(channel->slots[1], egk_norm);
+            OPL3_EnvelopeKeyOn(channel->pair->slots[0], egk_norm);
+            OPL3_EnvelopeKeyOn(channel->pair->slots[1], egk_norm);
         }
-        else if (channel->chtype == ch_2op || channel->chtype == ch_drum) {
-            eg_keyon(channel->slots[0], egk_norm);
-            eg_keyon(channel->slots[1], egk_norm);
+        else if (channel->chtype == ch_2op || channel->chtype == ch_drum)
+        {
+            OPL3_EnvelopeKeyOn(channel->slots[0], egk_norm);
+            OPL3_EnvelopeKeyOn(channel->slots[1], egk_norm);
         }
     }
-    else {
-        eg_keyon(channel->slots[0], egk_norm);
-        eg_keyon(channel->slots[1], egk_norm);
+    else
+    {
+        OPL3_EnvelopeKeyOn(channel->slots[0], egk_norm);
+        OPL3_EnvelopeKeyOn(channel->slots[1], egk_norm);
     }
 }
 
-void chan_disable(opl_channel *channel) {
-    if (channel->chip->newm) {
-        if (channel->chtype == ch_4op) {
-            eg_keyoff(channel->slots[0], egk_norm);
-            eg_keyoff(channel->slots[1], egk_norm);
-            eg_keyoff(channel->pair->slots[0], egk_norm);
-            eg_keyoff(channel->pair->slots[1], egk_norm);
+static void OPL3_ChannelKeyOff(opl3_channel *channel)
+{
+    if (channel->chip->newm)
+    {
+        if (channel->chtype == ch_4op)
+        {
+            OPL3_EnvelopeKeyOff(channel->slots[0], egk_norm);
+            OPL3_EnvelopeKeyOff(channel->slots[1], egk_norm);
+            OPL3_EnvelopeKeyOff(channel->pair->slots[0], egk_norm);
+            OPL3_EnvelopeKeyOff(channel->pair->slots[1], egk_norm);
         }
-        else if (channel->chtype == ch_2op || channel->chtype == ch_drum) {
-            eg_keyoff(channel->slots[0], egk_norm);
-            eg_keyoff(channel->slots[1], egk_norm);
+        else if (channel->chtype == ch_2op || channel->chtype == ch_drum)
+        {
+            OPL3_EnvelopeKeyOff(channel->slots[0], egk_norm);
+            OPL3_EnvelopeKeyOff(channel->slots[1], egk_norm);
         }
     }
-    else {
-        eg_keyoff(channel->slots[0], egk_norm);
-        eg_keyoff(channel->slots[1], egk_norm);
+    else
+    {
+        OPL3_EnvelopeKeyOff(channel->slots[0], egk_norm);
+        OPL3_EnvelopeKeyOff(channel->slots[1], egk_norm);
     }
 }
 
-void chan_set4op(opl_chip *chip, Bit8u data) {
+static void OPL3_ChannelSet4Op(opl3_chip *chip, Bit8u data)
+{
     Bit8u bit;
     Bit8u chnum;
-    for (bit = 0; bit < 6; bit++) {
+    for (bit = 0; bit < 6; bit++)
+    {
         chnum = bit;
-        if (bit >= 3) {
+        if (bit >= 3)
+        {
             chnum += 9 - 3;
         }
-        if ((data >> bit) & 0x01) {
+        if ((data >> bit) & 0x01)
+        {
             chip->channel[chnum].chtype = ch_4op;
             chip->channel[chnum + 3].chtype = ch_4op2;
         }
-        else {
+        else
+        {
             chip->channel[chnum].chtype = ch_2op;
             chip->channel[chnum + 3].chtype = ch_2op;
         }
     }
 }
 
-Bit16s limshort(Bit32s a) {
-    if (a > 32767) {
-        a = 32767;
+static Bit16s OPL3_ClipSample(Bit32s sample)
+{
+    if (sample > 32767)
+    {
+        sample = 32767;
     }
-    else if (a < -32768) {
-        a = -32768;
+    else if (sample < -32768)
+    {
+        sample = -32768;
     }
-    return (Bit16s)a;
+    return (Bit16s)sample;
 }
 
-void chip_generate(opl_chip *chip, Bit16s *buff) {
+void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
+{
     Bit8u ii;
     Bit8u jj;
     Bit16s accm;
+    Bit8u shift = 0;
 
-    buff[1] = limshort(chip->mixbuff[1]);
+    buf[1] = OPL3_ClipSample(chip->mixbuff[1]);
 
-    for (ii = 0; ii < 12; ii++) {
-        slot_calcfb(&chip->slot[ii]);
-        pg_generate(&chip->slot[ii]);
-        envelope_calc(&chip->slot[ii]);
-        slot_generate(&chip->slot[ii]);
-    }
-
-    for (ii = 12; ii < 15; ii++) {
-        slot_calcfb(&chip->slot[ii]);
-        pg_generate(&chip->slot[ii]);
-        envelope_calc(&chip->slot[ii]);
-    }
-
-    if (chip->rhy & 0x20) {
-        chan_generaterhythm1(chip);
-    }
-    else {
-        slot_generate(&chip->slot[12]);
-        slot_generate(&chip->slot[13]);
-        slot_generate(&chip->slot[14]);
+    for (ii = 0; ii < 15; ii++)
+    {
+        OPL3_SlotCalcFB(&chip->slot[ii]);
+        OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
+        OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
     chip->mixbuff[0] = 0;
-    for (ii = 0; ii < 18; ii++) {
+    for (ii = 0; ii < 18; ii++)
+    {
         accm = 0;
-        for (jj = 0; jj < 4; jj++) {
+        for (jj = 0; jj < 4; jj++)
+        {
             accm += *chip->channel[ii].out[jj];
         }
         chip->mixbuff[0] += (Bit16s)(accm & chip->channel[ii].cha);
     }
 
-    for (ii = 15; ii < 18; ii++) {
-        slot_calcfb(&chip->slot[ii]);
-        pg_generate(&chip->slot[ii]);
-        envelope_calc(&chip->slot[ii]);
+    for (ii = 15; ii < 18; ii++)
+    {
+        OPL3_SlotCalcFB(&chip->slot[ii]);
+        OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
+        OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
-    if (chip->rhy & 0x20) {
-        chan_generaterhythm2(chip);
-    }
-    else {
-        slot_generate(&chip->slot[15]);
-        slot_generate(&chip->slot[16]);
-        slot_generate(&chip->slot[17]);
-    }
+    buf[0] = OPL3_ClipSample(chip->mixbuff[0]);
 
-    buff[0] = limshort(chip->mixbuff[0]);
-
-    for (ii = 18; ii < 33; ii++) {
-        slot_calcfb(&chip->slot[ii]);
-        pg_generate(&chip->slot[ii]);
-        envelope_calc(&chip->slot[ii]);
-        slot_generate(&chip->slot[ii]);
+    for (ii = 18; ii < 33; ii++)
+    {
+        OPL3_SlotCalcFB(&chip->slot[ii]);
+        OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
+        OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
     chip->mixbuff[1] = 0;
-    for (ii = 0; ii < 18; ii++) {
+    for (ii = 0; ii < 18; ii++)
+    {
         accm = 0;
-        for (jj = 0; jj < 4; jj++) {
+        for (jj = 0; jj < 4; jj++)
+        {
             accm += *chip->channel[ii].out[jj];
         }
         chip->mixbuff[1] += (Bit16s)(accm & chip->channel[ii].chb);
     }
 
-    for (ii = 33; ii < 36; ii++) {
-        slot_calcfb(&chip->slot[ii]);
-        pg_generate(&chip->slot[ii]);
-        envelope_calc(&chip->slot[ii]);
-        slot_generate(&chip->slot[ii]);
+    for (ii = 33; ii < 36; ii++)
+    {
+        OPL3_SlotCalcFB(&chip->slot[ii]);
+        OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
+        OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
-    n_generate(chip);
+    if ((chip->timer & 0x3f) == 0x3f)
+    {
+        chip->tremolopos = (chip->tremolopos + 1) % 210;
+    }
+    if (chip->tremolopos < 105)
+    {
+        chip->tremolo = chip->tremolopos >> chip->tremoloshift;
+    }
+    else
+    {
+        chip->tremolo = (210 - chip->tremolopos) >> chip->tremoloshift;
+    }
 
-    if ((chip->timer & 0x3f) == 0x3f) {
-        if (!chip->tremdir) {
-            if (chip->tremtval == 105) {
-                chip->tremtval--;
-                chip->tremdir = 1;
-            }
-            else {
-                chip->tremtval++;
-            }
-        }
-        else {
-            if (chip->tremtval == 0) {
-                chip->tremtval++;
-                chip->tremdir = 0;
-            }
-            else {
-                chip->tremtval--;
-            }
-        }
-        chip->tremval = (chip->tremtval >> 2) >> ((1 - chip->dam) << 1);
+    if ((chip->timer & 0x3ff) == 0x3ff)
+    {
+        chip->vibpos = (chip->vibpos + 1) & 7;
     }
 
     chip->timer++;
+
+    chip->eg_add = 0;
+    if (chip->eg_timer)
+    {
+        while (shift < 36 && ((chip->eg_timer >> shift) & 1) == 0)
+        {
+            shift++;
+        }
+        if (shift > 12)
+        {
+            chip->eg_add = 0;
+        }
+        else
+        {
+            chip->eg_add = shift + 1;
+        }
+    }
+
+    if (chip->eg_timerrem || chip->eg_state)
+    {
+        if (chip->eg_timer == 0xfffffffff)
+        {
+            chip->eg_timer = 0;
+            chip->eg_timerrem = 1;
+        }
+        else
+        {
+            chip->eg_timer++;
+            chip->eg_timerrem = 0;
+        }
+    }
+
+    chip->eg_state ^= 1;
+
+    while (chip->writebuf[chip->writebuf_cur].time <= chip->writebuf_samplecnt)
+    {
+        if (!(chip->writebuf[chip->writebuf_cur].reg & 0x200))
+        {
+            break;
+        }
+        chip->writebuf[chip->writebuf_cur].reg &= 0x1ff;
+        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_cur].reg,
+                      chip->writebuf[chip->writebuf_cur].data);
+        chip->writebuf_cur = (chip->writebuf_cur + 1) % OPL_WRITEBUF_SIZE;
+    }
+    chip->writebuf_samplecnt++;
 }
 
-void chip_generate_opl3l(opl_chip *chip, Bit16s *buffer)
+void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf)
 {
-    while (chip->samplecnt / 57)
+    while (chip->samplecnt >= chip->rateratio)
     {
         chip->oldsamples[0] = chip->samples[0];
         chip->oldsamples[1] = chip->samples[1];
-        chip_generate(chip, chip->samples);
-        chip->samplecnt -= 57;
+        OPL3_Generate(chip, chip->samples);
+        chip->samplecnt -= chip->rateratio;
     }
-    buffer[0] = (Bit16s)((chip->oldsamples[0] * (57 - chip->samplecnt) + chip->samples[0] * chip->samplecnt) / 57);
-    buffer[1] = (Bit16s)((chip->oldsamples[1] * (57 - chip->samplecnt) + chip->samples[1] * chip->samplecnt) / 57);
-    chip->samplecnt += 64;
+    buf[0] = (Bit16s)((chip->oldsamples[0] * (chip->rateratio - chip->samplecnt)
+                     + chip->samples[0] * chip->samplecnt) / chip->rateratio);
+    buf[1] = (Bit16s)((chip->oldsamples[1] * (chip->rateratio - chip->samplecnt)
+                     + chip->samples[1] * chip->samplecnt) / chip->rateratio);
+    chip->samplecnt += 1 << RSM_FRAC;
 }
 
-void chip_reset(opl_chip *chip, Bit32u samplerate) {
+void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
+{
     Bit8u slotnum;
     Bit8u channum;
 
-    memset(chip, 0, sizeof(opl_chip));
-    for (slotnum = 0; slotnum < 36; slotnum++) {
+    memset(chip, 0, sizeof(opl3_chip));
+    for (slotnum = 0; slotnum < 36; slotnum++)
+    {
         chip->slot[slotnum].chip = chip;
         chip->slot[slotnum].mod = &chip->zeromod;
         chip->slot[slotnum].eg_rout = 0x1ff;
         chip->slot[slotnum].eg_out = 0x1ff;
-        chip->slot[slotnum].eg_gen = envelope_gen_num_off;
+        chip->slot[slotnum].eg_gen = envelope_gen_num_release;
         chip->slot[slotnum].trem = (Bit8u*)&chip->zeromod;
+        chip->slot[slotnum].slot_num = slotnum;
     }
-    for (channum = 0; channum < 18; channum++) {
+    for (channum = 0; channum < 18; channum++)
+    {
         chip->channel[channum].slots[0] = &chip->slot[ch_slot[channum]];
         chip->channel[channum].slots[1] = &chip->slot[ch_slot[channum] + 3];
         chip->slot[ch_slot[channum]].channel = &chip->channel[channum];
         chip->slot[ch_slot[channum] + 3].channel = &chip->channel[channum];
-        if ((channum % 9) < 3) {
+        if ((channum % 9) < 3)
+        {
             chip->channel[channum].pair = &chip->channel[channum + 3];
         }
-        else if ((channum % 9) < 6) {
+        else if ((channum % 9) < 6)
+        {
             chip->channel[channum].pair = &chip->channel[channum - 3];
         }
         chip->channel[channum].chip = chip;
@@ -1018,32 +1227,40 @@ void chip_reset(opl_chip *chip, Bit32u samplerate) {
         chip->channel[channum].out[2] = &chip->zeromod;
         chip->channel[channum].out[3] = &chip->zeromod;
         chip->channel[channum].chtype = ch_2op;
-        chip->channel[channum].cha = ~0;
-        chip->channel[channum].chb = ~0;
-        chip->channel[channum].fcha = 1.0;
-        chip->channel[channum].fchb = 1.0;
-        chan_setupalg(&chip->channel[channum]);
+        chip->channel[channum].cha = 0xffff;
+        chip->channel[channum].chb = 0xffff;
+        chip->channel[channum].ch_num = channum;
+        OPL3_ChannelSetupAlg(&chip->channel[channum]);
     }
-    chip->noise = 0x306600;
+    chip->noise = 1;
+    chip->rateratio = (samplerate << RSM_FRAC) / 49716;
+    chip->tremoloshift = 4;
+    chip->vibshift = 1;
 }
 
-void chip_write(opl_chip *chip, Bit16u reg, Bit8u v) {
+void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
+{
     Bit8u high = (reg >> 8) & 0x01;
     Bit8u regm = reg & 0xff;
-    switch (regm & 0xf0) {
+    switch (regm & 0xf0)
+    {
     case 0x00:
-        if (high) {
-            switch (regm & 0x0f) {
+        if (high)
+        {
+            switch (regm & 0x0f)
+            {
             case 0x04:
-                chan_set4op(chip, v);
+                OPL3_ChannelSet4Op(chip, v);
                 break;
             case 0x05:
                 chip->newm = v & 0x01;
                 break;
             }
         }
-        else {
-            switch (regm & 0x0f) {
+        else
+        {
+            switch (regm & 0x0f)
+            {
             case 0x08:
                 chip->nts = (v >> 6) & 0x01;
                 break;
@@ -1052,59 +1269,116 @@ void chip_write(opl_chip *chip, Bit16u reg, Bit8u v) {
         break;
     case 0x20:
     case 0x30:
-        if (ad_slot[regm & 0x1f] >= 0) {
-            slot_write20(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
+        if (ad_slot[regm & 0x1f] >= 0)
+        {
+            OPL3_SlotWrite20(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
         }
         break;
     case 0x40:
     case 0x50:
-        if (ad_slot[regm & 0x1f] >= 0) {
-            slot_write40(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
+        if (ad_slot[regm & 0x1f] >= 0)
+        {
+            OPL3_SlotWrite40(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
         }
         break;
     case 0x60:
     case 0x70:
-        if (ad_slot[regm & 0x1f] >= 0) {
-            slot_write60(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
+        if (ad_slot[regm & 0x1f] >= 0)
+        {
+            OPL3_SlotWrite60(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
         }
         break;
     case 0x80:
     case 0x90:
-        if (ad_slot[regm & 0x1f] >= 0) {
-            slot_write80(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);;
+        if (ad_slot[regm & 0x1f] >= 0)
+        {
+            OPL3_SlotWrite80(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
         }
         break;
     case 0xe0:
     case 0xf0:
-        if (ad_slot[regm & 0x1f] >= 0) {
-            slot_writee0(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
+        if (ad_slot[regm & 0x1f] >= 0)
+        {
+            OPL3_SlotWriteE0(&chip->slot[18 * high + ad_slot[regm & 0x1f]], v);
         }
         break;
     case 0xa0:
-        if ((regm & 0x0f) < 9) {
-            chan_writea0(&chip->channel[9 * high + (regm & 0x0f)], v);
+        if ((regm & 0x0f) < 9)
+        {
+            OPL3_ChannelWriteA0(&chip->channel[9 * high + (regm & 0x0f)], v);
         }
         break;
     case 0xb0:
-        if (regm == 0xbd && !high) {
-            chip->dam = v >> 7;
-            chip->dvb = (v >> 6) & 0x01;
-            chan_updaterhythm(chip, v);
+        if (regm == 0xbd && !high)
+        {
+            chip->tremoloshift = (((v >> 7) ^ 1) << 1) + 2;
+            chip->vibshift = ((v >> 6) & 0x01) ^ 1;
+            OPL3_ChannelUpdateRhythm(chip, v);
         }
-        else if ((regm & 0x0f) < 9) {
-            chan_writeb0(&chip->channel[9 * high + (regm & 0x0f)], v);
-            if (v & 0x20) {
-                chan_enable(&chip->channel[9 * high + (regm & 0x0f)]);
+        else if ((regm & 0x0f) < 9)
+        {
+            OPL3_ChannelWriteB0(&chip->channel[9 * high + (regm & 0x0f)], v);
+            if (v & 0x20)
+            {
+                OPL3_ChannelKeyOn(&chip->channel[9 * high + (regm & 0x0f)]);
             }
-            else {
-                chan_disable(&chip->channel[9 * high + (regm & 0x0f)]);
+            else
+            {
+                OPL3_ChannelKeyOff(&chip->channel[9 * high + (regm & 0x0f)]);
             }
         }
         break;
     case 0xc0:
-        if ((regm & 0x0f) < 9) {
-            chan_writec0(&chip->channel[9 * high + (regm & 0x0f)], v);
+        if ((regm & 0x0f) < 9)
+        {
+            OPL3_ChannelWriteC0(&chip->channel[9 * high + (regm & 0x0f)], v);
         }
         break;
+    }
+}
+
+void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v)
+{
+    Bit64u time1, time2;
+
+    if (chip->writebuf[chip->writebuf_last].reg & 0x200)
+    {
+        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_last].reg & 0x1ff,
+                      chip->writebuf[chip->writebuf_last].data);
+
+        chip->writebuf_cur = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+        chip->writebuf_samplecnt = chip->writebuf[chip->writebuf_last].time;
+    }
+
+    chip->writebuf[chip->writebuf_last].reg = reg | 0x200;
+    chip->writebuf[chip->writebuf_last].data = v;
+    time1 = chip->writebuf_lasttime + OPL_WRITEBUF_DELAY;
+    time2 = chip->writebuf_samplecnt;
+
+    if (time1 < time2)
+    {
+        time1 = time2;
+    }
+
+    chip->writebuf[chip->writebuf_last].time = time1;
+    chip->writebuf_lasttime = time1;
+    chip->writebuf_last = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+}
+
+void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
+{
+    Bit32u i;
+
+    for(i = 0; i < numsamples; i++)
+    {
+        if (chip->rateratio == 1 << RSM_FRAC)
+        {
+            OPL3_Generate(chip, sndptr);
+        }
+        else
+        {
+            OPL3_GenerateResampled(chip, sndptr);
+        }
+        sndptr += 2;
     }
 }

--- a/doomopl/driver/fmopl3lib/opl3.h
+++ b/doomopl/driver/fmopl3lib/opl3.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2015 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -20,28 +20,38 @@
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.6.1
+// version: 1.8
 //
 
-#include <stdint.h>
+#ifndef OPL_OPL3_H
+#define OPL_OPL3_H
 
-typedef uint8_t             Bit8u;
-typedef int8_t              Bit8s;
-typedef uint16_t            Bit16u;
-typedef int16_t             Bit16s;
-typedef uint32_t            Bit32u;
-typedef int32_t             Bit32s;
-typedef uint64_t            Bit64u;
-typedef int64_t             Bit64s;
+#include <inttypes.h>
 
-typedef struct _opl_slot opl_slot;
-typedef struct _opl_channel opl_channel;
-typedef struct _opl_chip opl_chip;
+#define OPL_WRITEBUF_SIZE   1024
+#define OPL_WRITEBUF_DELAY  2
 
-struct _opl_slot {
-    opl_channel *channel;
-    opl_chip *chip;
+typedef uintptr_t       Bitu;
+typedef intptr_t        Bits;
+typedef uint64_t        Bit64u;
+typedef int64_t         Bit64s;
+typedef uint32_t        Bit32u;
+typedef int32_t         Bit32s;
+typedef uint16_t        Bit16u;
+typedef int16_t         Bit16s;
+typedef uint8_t         Bit8u;
+typedef int8_t          Bit8s;
+
+typedef struct _opl3_slot opl3_slot;
+typedef struct _opl3_channel opl3_channel;
+typedef struct _opl3_chip opl3_chip;
+
+struct _opl3_slot {
+    opl3_channel *channel;
+    opl3_chip *chip;
     Bit16s out;
     Bit16s fbmod;
     Bit16s *mod;
@@ -65,14 +75,16 @@ struct _opl_slot {
     Bit8u reg_rr;
     Bit8u reg_wf;
     Bit8u key;
+    Bit32u pg_reset;
     Bit32u pg_phase;
-    Bit32u timer;
+    Bit16u pg_phase_out;
+    Bit8u slot_num;
 };
 
-struct _opl_channel {
-    opl_slot *slots[2];
-    opl_channel *pair;
-    opl_chip *chip;
+struct _opl3_channel {
+    opl3_slot *slots[2];
+    opl3_channel *pair;
+    opl3_chip *chip;
     Bit16s *out[4];
     Bit8u chtype;
     Bit16u f_num;
@@ -82,32 +94,57 @@ struct _opl_channel {
     Bit8u alg;
     Bit8u ksv;
     Bit16u cha, chb;
-    float fcha, fchb;
+    Bit8u ch_num;
 };
 
-struct _opl_chip {
-    opl_channel channel[18];
-    opl_slot slot[36];
+typedef struct _opl3_writebuf {
+    Bit64u time;
+    Bit16u reg;
+    Bit8u data;
+} opl3_writebuf;
+
+struct _opl3_chip {
+    opl3_channel channel[18];
+    opl3_slot slot[36];
     Bit16u timer;
+    Bit64u eg_timer;
+    Bit8u eg_timerrem;
+    Bit8u eg_state;
+    Bit8u eg_add;
     Bit8u newm;
     Bit8u nts;
-    Bit8u dvb;
-    Bit8u dam;
     Bit8u rhy;
     Bit8u vibpos;
-    Bit8u tremval;
-    Bit8u tremtval;
-    Bit8u tremdir;
+    Bit8u vibshift;
+    Bit8u tremolo;
+    Bit8u tremolopos;
+    Bit8u tremoloshift;
     Bit32u noise;
     Bit16s zeromod;
     Bit32s mixbuff[2];
+    Bit8u rm_hh_bit2;
+    Bit8u rm_hh_bit3;
+    Bit8u rm_hh_bit7;
+    Bit8u rm_hh_bit8;
+    Bit8u rm_tc_bit3;
+    Bit8u rm_tc_bit5;
     //OPL3L
+    Bit32s rateratio;
     Bit32s samplecnt;
     Bit16s oldsamples[2];
     Bit16s samples[2];
+
+    Bit64u writebuf_samplecnt;
+    Bit32u writebuf_cur;
+    Bit32u writebuf_last;
+    Bit64u writebuf_lasttime;
+    opl3_writebuf writebuf[OPL_WRITEBUF_SIZE];
 };
 
-
-void chip_reset(opl_chip *chip, Bit32u samplerate);
-void chip_write(opl_chip *chip, Bit16u reg, Bit8u v);
-void chip_generate(opl_chip *chip, Bit16s *buff);
+void OPL3_Generate(opl3_chip *chip, Bit16s *buf);
+void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf);
+void OPL3_Reset(opl3_chip *chip, Bit32u samplerate);
+void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v);
+void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v);
+void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
+#endif

--- a/doomopl/driver/fmopl3lib/opl3class.h
+++ b/doomopl/driver/fmopl3lib/opl3class.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2015-2017 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -12,19 +12,13 @@
 // GNU General Public License for more details.
 //
 
-#include "..\interface.h"
+#include "../interface.h"
 #include "opl3.h"
 
 
 class opl3class : public fm_chip {
 private:
-    opl_chip chip;
-    Bit64u counter;
-    Bit64u lastwrite;
-    Bit16u command[8192][2];
-    Bit64u time[8192];
-    Bit16u strpos;
-    Bit16s endpos;
+    opl3_chip chip;
 public:
 	int fm_init(unsigned int rate);
 	void fm_writereg(unsigned short reg, unsigned char data);

--- a/doomopl_ext/driver/fmopl3lib/opl3.cpp
+++ b/doomopl_ext/driver/fmopl3lib/opl3.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2017 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -20,8 +20,10 @@
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.7.4
+// version: 1.8
 //
 
 #include <stdio.h>
@@ -94,38 +96,38 @@ static const Bit16u logsinrom[256] = {
 //
 
 static const Bit16u exprom[256] = {
-    0x000, 0x003, 0x006, 0x008, 0x00b, 0x00e, 0x011, 0x014,
-    0x016, 0x019, 0x01c, 0x01f, 0x022, 0x025, 0x028, 0x02a,
-    0x02d, 0x030, 0x033, 0x036, 0x039, 0x03c, 0x03f, 0x042,
-    0x045, 0x048, 0x04b, 0x04e, 0x051, 0x054, 0x057, 0x05a,
-    0x05d, 0x060, 0x063, 0x066, 0x069, 0x06c, 0x06f, 0x072,
-    0x075, 0x078, 0x07b, 0x07e, 0x082, 0x085, 0x088, 0x08b,
-    0x08e, 0x091, 0x094, 0x098, 0x09b, 0x09e, 0x0a1, 0x0a4,
-    0x0a8, 0x0ab, 0x0ae, 0x0b1, 0x0b5, 0x0b8, 0x0bb, 0x0be,
-    0x0c2, 0x0c5, 0x0c8, 0x0cc, 0x0cf, 0x0d2, 0x0d6, 0x0d9,
-    0x0dc, 0x0e0, 0x0e3, 0x0e7, 0x0ea, 0x0ed, 0x0f1, 0x0f4,
-    0x0f8, 0x0fb, 0x0ff, 0x102, 0x106, 0x109, 0x10c, 0x110,
-    0x114, 0x117, 0x11b, 0x11e, 0x122, 0x125, 0x129, 0x12c,
-    0x130, 0x134, 0x137, 0x13b, 0x13e, 0x142, 0x146, 0x149,
-    0x14d, 0x151, 0x154, 0x158, 0x15c, 0x160, 0x163, 0x167,
-    0x16b, 0x16f, 0x172, 0x176, 0x17a, 0x17e, 0x181, 0x185,
-    0x189, 0x18d, 0x191, 0x195, 0x199, 0x19c, 0x1a0, 0x1a4,
-    0x1a8, 0x1ac, 0x1b0, 0x1b4, 0x1b8, 0x1bc, 0x1c0, 0x1c4,
-    0x1c8, 0x1cc, 0x1d0, 0x1d4, 0x1d8, 0x1dc, 0x1e0, 0x1e4,
-    0x1e8, 0x1ec, 0x1f0, 0x1f5, 0x1f9, 0x1fd, 0x201, 0x205,
-    0x209, 0x20e, 0x212, 0x216, 0x21a, 0x21e, 0x223, 0x227,
-    0x22b, 0x230, 0x234, 0x238, 0x23c, 0x241, 0x245, 0x249,
-    0x24e, 0x252, 0x257, 0x25b, 0x25f, 0x264, 0x268, 0x26d,
-    0x271, 0x276, 0x27a, 0x27f, 0x283, 0x288, 0x28c, 0x291,
-    0x295, 0x29a, 0x29e, 0x2a3, 0x2a8, 0x2ac, 0x2b1, 0x2b5,
-    0x2ba, 0x2bf, 0x2c4, 0x2c8, 0x2cd, 0x2d2, 0x2d6, 0x2db,
-    0x2e0, 0x2e5, 0x2e9, 0x2ee, 0x2f3, 0x2f8, 0x2fd, 0x302,
-    0x306, 0x30b, 0x310, 0x315, 0x31a, 0x31f, 0x324, 0x329,
-    0x32e, 0x333, 0x338, 0x33d, 0x342, 0x347, 0x34c, 0x351,
-    0x356, 0x35b, 0x360, 0x365, 0x36a, 0x370, 0x375, 0x37a,
-    0x37f, 0x384, 0x38a, 0x38f, 0x394, 0x399, 0x39f, 0x3a4,
-    0x3a9, 0x3ae, 0x3b4, 0x3b9, 0x3bf, 0x3c4, 0x3c9, 0x3cf,
-    0x3d4, 0x3da, 0x3df, 0x3e4, 0x3ea, 0x3ef, 0x3f5, 0x3fa
+    0x7fa, 0x7f5, 0x7ef, 0x7ea, 0x7e4, 0x7df, 0x7da, 0x7d4,
+    0x7cf, 0x7c9, 0x7c4, 0x7bf, 0x7b9, 0x7b4, 0x7ae, 0x7a9,
+    0x7a4, 0x79f, 0x799, 0x794, 0x78f, 0x78a, 0x784, 0x77f,
+    0x77a, 0x775, 0x770, 0x76a, 0x765, 0x760, 0x75b, 0x756,
+    0x751, 0x74c, 0x747, 0x742, 0x73d, 0x738, 0x733, 0x72e,
+    0x729, 0x724, 0x71f, 0x71a, 0x715, 0x710, 0x70b, 0x706,
+    0x702, 0x6fd, 0x6f8, 0x6f3, 0x6ee, 0x6e9, 0x6e5, 0x6e0,
+    0x6db, 0x6d6, 0x6d2, 0x6cd, 0x6c8, 0x6c4, 0x6bf, 0x6ba,
+    0x6b5, 0x6b1, 0x6ac, 0x6a8, 0x6a3, 0x69e, 0x69a, 0x695,
+    0x691, 0x68c, 0x688, 0x683, 0x67f, 0x67a, 0x676, 0x671,
+    0x66d, 0x668, 0x664, 0x65f, 0x65b, 0x657, 0x652, 0x64e,
+    0x649, 0x645, 0x641, 0x63c, 0x638, 0x634, 0x630, 0x62b,
+    0x627, 0x623, 0x61e, 0x61a, 0x616, 0x612, 0x60e, 0x609,
+    0x605, 0x601, 0x5fd, 0x5f9, 0x5f5, 0x5f0, 0x5ec, 0x5e8,
+    0x5e4, 0x5e0, 0x5dc, 0x5d8, 0x5d4, 0x5d0, 0x5cc, 0x5c8,
+    0x5c4, 0x5c0, 0x5bc, 0x5b8, 0x5b4, 0x5b0, 0x5ac, 0x5a8,
+    0x5a4, 0x5a0, 0x59c, 0x599, 0x595, 0x591, 0x58d, 0x589,
+    0x585, 0x581, 0x57e, 0x57a, 0x576, 0x572, 0x56f, 0x56b,
+    0x567, 0x563, 0x560, 0x55c, 0x558, 0x554, 0x551, 0x54d,
+    0x549, 0x546, 0x542, 0x53e, 0x53b, 0x537, 0x534, 0x530,
+    0x52c, 0x529, 0x525, 0x522, 0x51e, 0x51b, 0x517, 0x514,
+    0x510, 0x50c, 0x509, 0x506, 0x502, 0x4ff, 0x4fb, 0x4f8,
+    0x4f4, 0x4f1, 0x4ed, 0x4ea, 0x4e7, 0x4e3, 0x4e0, 0x4dc,
+    0x4d9, 0x4d6, 0x4d2, 0x4cf, 0x4cc, 0x4c8, 0x4c5, 0x4c2,
+    0x4be, 0x4bb, 0x4b8, 0x4b5, 0x4b1, 0x4ae, 0x4ab, 0x4a8,
+    0x4a4, 0x4a1, 0x49e, 0x49b, 0x498, 0x494, 0x491, 0x48e,
+    0x48b, 0x488, 0x485, 0x482, 0x47e, 0x47b, 0x478, 0x475,
+    0x472, 0x46f, 0x46c, 0x469, 0x466, 0x463, 0x460, 0x45d,
+    0x45a, 0x457, 0x454, 0x451, 0x44e, 0x44b, 0x448, 0x445,
+    0x442, 0x43f, 0x43c, 0x439, 0x436, 0x433, 0x430, 0x42d,
+    0x42a, 0x428, 0x425, 0x422, 0x41f, 0x41c, 0x419, 0x416,
+    0x414, 0x411, 0x40e, 0x40b, 0x408, 0x406, 0x403, 0x400
 };
 
 //
@@ -154,33 +156,11 @@ static const Bit8u kslshift[4] = {
 // envelope generator constants
 //
 
-static const Bit8u eg_incstep[3][4][8] = {
-    {
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 }
-    },
-    {
-        { 0, 1, 0, 1, 0, 1, 0, 1 },
-        { 0, 1, 0, 1, 1, 1, 0, 1 },
-        { 0, 1, 1, 1, 0, 1, 1, 1 },
-        { 0, 1, 1, 1, 1, 1, 1, 1 }
-    },
-    {
-        { 1, 1, 1, 1, 1, 1, 1, 1 },
-        { 2, 2, 1, 1, 1, 1, 1, 1 },
-        { 2, 2, 1, 1, 2, 2, 1, 1 },
-        { 2, 2, 2, 2, 2, 2, 1, 1 }
-    }
-};
-
-static const Bit8u eg_incdesc[16] = {
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2
-};
-
-static const Bit8s eg_incsh[16] = {
-    0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, -1, -2
+static const Bit8u eg_incstep[4][4] = {
+    { 0, 0, 0, 0 },
+    { 1, 0, 0, 0 },
+    { 1, 0, 1, 0 },
+    { 1, 1, 1, 0 }
 };
 
 //
@@ -212,7 +192,7 @@ static Bit16s OPL3_EnvelopeCalcExp(Bit32u level)
     {
         level = 0x1fff;
     }
-    return ((exprom[(level & 0xff) ^ 0xff] | 0x400) << 1) >> (level >> 8);
+    return (exprom[level & 0xff] << 1) >> (level >> 8);
 }
 
 static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
@@ -222,7 +202,7 @@ static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     if (phase & 0x100)
     {
@@ -291,7 +271,7 @@ static Bit16s OPL3_EnvelopeCalcSin4(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if ((phase & 0x300) == 0x100)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     if (phase & 0x200)
     {
@@ -333,7 +313,7 @@ static Bit16s OPL3_EnvelopeCalcSin6(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     return OPL3_EnvelopeCalcExp(envelope << 3) ^ neg;
 }
@@ -345,7 +325,7 @@ static Bit16s OPL3_EnvelopeCalcSin7(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
         phase = (phase & 0x1ff) ^ 0x1ff;
     }
     out = phase << 3;
@@ -363,44 +343,13 @@ static const envelope_sinfunc envelope_sin[8] = {
     OPL3_EnvelopeCalcSin7
 };
 
-static void OPL3_EnvelopeGenOff(opl3_slot *slot);
-static void OPL3_EnvelopeGenAttack(opl3_slot *slot);
-static void OPL3_EnvelopeGenDecay(opl3_slot *slot);
-static void OPL3_EnvelopeGenSustain(opl3_slot *slot);
-static void OPL3_EnvelopeGenRelease(opl3_slot *slot);
-
-envelope_genfunc envelope_gen[5] = {
-    OPL3_EnvelopeGenOff,
-    OPL3_EnvelopeGenAttack,
-    OPL3_EnvelopeGenDecay,
-    OPL3_EnvelopeGenSustain,
-    OPL3_EnvelopeGenRelease
-};
-
 enum envelope_gen_num
 {
-    envelope_gen_num_off = 0,
-    envelope_gen_num_attack = 1,
-    envelope_gen_num_decay = 2,
-    envelope_gen_num_sustain = 3,
-    envelope_gen_num_release = 4
+    envelope_gen_num_attack = 0,
+    envelope_gen_num_decay = 1,
+    envelope_gen_num_sustain = 2,
+    envelope_gen_num_release = 3
 };
-
-static Bit8u OPL3_EnvelopeCalcRate(opl3_slot *slot, Bit8u reg_rate)
-{
-    Bit8u rate;
-    if (reg_rate == 0x00)
-    {
-        return 0x00;
-    }
-    rate = (reg_rate << 2)
-         + (slot->reg_ksr ? slot->channel->ksv : (slot->channel->ksv >> 2));
-    if (rate > 0x3c)
-    {
-        rate = 0x3c;
-    }
-    return rate;
-}
 
 static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
 {
@@ -413,128 +362,161 @@ static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
     slot->eg_ksl = (Bit8u)ksl;
 }
 
-static void OPL3_EnvelopeUpdateRate(opl3_slot *slot)
-{
-    switch (slot->eg_gen)
-    {
-    case envelope_gen_num_off:
-    case envelope_gen_num_attack:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_ar);
-        break;
-    case envelope_gen_num_decay:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_dr);
-        break;
-    case envelope_gen_num_sustain:
-    case envelope_gen_num_release:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_rr);
-        break;
-    }
-}
-
-static void OPL3_EnvelopeGenOff(opl3_slot *slot)
-{
-    slot->eg_rout = 0x1ff;
-}
-
-static void OPL3_EnvelopeGenAttack(opl3_slot *slot)
-{
-    if (slot->eg_rout == 0x00)
-    {
-        slot->eg_gen = envelope_gen_num_decay;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += ((~slot->eg_rout) * slot->eg_inc) >> 3;
-    if (slot->eg_rout < 0x00)
-    {
-        slot->eg_rout = 0x00;
-    }
-}
-
-static void OPL3_EnvelopeGenDecay(opl3_slot *slot)
-{
-    if (slot->eg_rout >= slot->reg_sl << 4)
-    {
-        slot->eg_gen = envelope_gen_num_sustain;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
-static void OPL3_EnvelopeGenSustain(opl3_slot *slot)
-{
-    if (!slot->reg_type)
-    {
-        OPL3_EnvelopeGenRelease(slot);
-    }
-}
-
-static void OPL3_EnvelopeGenRelease(opl3_slot *slot)
-{
-    if (slot->eg_rout >= 0x1ff)
-    {
-        slot->eg_gen = envelope_gen_num_off;
-        slot->eg_rout = 0x1ff;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
 static void OPL3_EnvelopeCalc(opl3_slot *slot)
 {
-    Bit8u rate_h, rate_l;
-    Bit8u inc = 0;
-    rate_h = slot->eg_rate >> 2;
-    rate_l = slot->eg_rate & 3;
-    if (eg_incsh[rate_h] > 0)
+    Bit8u nonzero;
+    Bit8u rate;
+    Bit8u rate_hi;
+    Bit8u rate_lo;
+    Bit8u reg_rate = 0;
+    Bit8u ks;
+    Bit8u eg_shift, shift;
+    Bit16u eg_rout;
+    Bit16s eg_inc;
+    Bit8u eg_off;
+    Bit8u reset = 0;
+    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
+                 + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
+    if (slot->key && slot->eg_gen == envelope_gen_num_release)
     {
-        if ((slot->chip->timer & ((1 << eg_incsh[rate_h]) - 1)) == 0)
-        {
-            inc = eg_incstep[eg_incdesc[rate_h]][rate_l]
-                            [((slot->chip->timer)>> eg_incsh[rate_h]) & 0x07];
-        }
+        reset = 1;
+        reg_rate = slot->reg_ar;
     }
     else
     {
-        inc = eg_incstep[eg_incdesc[rate_h]][rate_l]
-                        [slot->chip->timer & 0x07] << (-eg_incsh[rate_h]);
+        switch (slot->eg_gen)
+        {
+        case envelope_gen_num_attack:
+            reg_rate = slot->reg_ar;
+            break;
+        case envelope_gen_num_decay:
+            reg_rate = slot->reg_dr;
+            break;
+        case envelope_gen_num_sustain:
+            if (!slot->reg_type)
+            {
+                reg_rate = slot->reg_rr;
+            }
+            break;
+        case envelope_gen_num_release:
+            reg_rate = slot->reg_rr;
+            break;
+        }
     }
-    slot->eg_inc = inc;
-    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
-                 + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
-    envelope_gen[slot->eg_gen](slot);
+    slot->pg_reset = reset;
+    ks = slot->channel->ksv >> ((slot->reg_ksr ^ 1) << 1);
+    nonzero = (reg_rate != 0);
+    rate = ks + (reg_rate << 2);
+    rate_hi = rate >> 2;
+    rate_lo = rate & 0x03;
+    if (rate_hi & 0x10)
+    {
+        rate_hi = 0x0f;
+    }
+    eg_shift = rate_hi + slot->chip->eg_add;
+    shift = 0;
+    if (nonzero)
+    {
+        if (rate_hi < 12)
+        {
+            if (slot->chip->eg_state)
+            {
+                switch (eg_shift)
+                {
+                case 12:
+                    shift = 1;
+                    break;
+                case 13:
+                    shift = (rate_lo >> 1) & 0x01;
+                    break;
+                case 14:
+                    shift = rate_lo & 0x01;
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+        else
+        {
+            shift = (rate_hi & 0x03) + eg_incstep[rate_lo][slot->chip->timer & 0x03];
+            if (shift & 0x04)
+            {
+                shift = 0x03;
+            }
+            if (!shift)
+            {
+                shift = slot->chip->eg_state;
+            }
+        }
+    }
+    eg_rout = slot->eg_rout;
+    eg_inc = 0;
+    eg_off = 0;
+    // Instant attack
+    if (reset && rate_hi == 0x0f)
+    {
+        eg_rout = 0x00;
+    }
+    // Envelope off
+    if ((slot->eg_rout & 0x1f8) == 0x1f8)
+    {
+        eg_off = 1;
+    }
+    if (slot->eg_gen != envelope_gen_num_attack && !reset && eg_off)
+    {
+        eg_rout = 0x1ff;
+    }
+    switch (slot->eg_gen)
+    {
+    case envelope_gen_num_attack:
+        if (!slot->eg_rout)
+        {
+            slot->eg_gen = envelope_gen_num_decay;
+        }
+        else if (slot->key && shift > 0 && rate_hi != 0x0f)
+        {
+            eg_inc = ((~slot->eg_rout) << shift) >> 4;
+        }
+        break;
+    case envelope_gen_num_decay:
+        if ((slot->eg_rout >> 4) == slot->reg_sl)
+        {
+            slot->eg_gen = envelope_gen_num_sustain;
+        }
+        else if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
+        break;
+    case envelope_gen_num_sustain:
+    case envelope_gen_num_release:
+        if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
+        break;
+    }
+    slot->eg_rout = (eg_rout + eg_inc) & 0x1ff;
+    // Key off
+    if (reset)
+    {
+        slot->eg_gen = envelope_gen_num_attack;
+    }
+    if (!slot->key)
+    {
+        slot->eg_gen = envelope_gen_num_release;
+    }
 }
 
 static void OPL3_EnvelopeKeyOn(opl3_slot *slot, Bit8u type)
 {
-    if (!slot->key)
-    {
-        slot->eg_gen = envelope_gen_num_attack;
-        OPL3_EnvelopeUpdateRate(slot);
-        if ((slot->eg_rate >> 2) == 0x0f)
-        {
-            slot->eg_gen = envelope_gen_num_decay;
-            OPL3_EnvelopeUpdateRate(slot);
-            slot->eg_rout = 0x00;
-        }
-        slot->pg_phase = 0x00;
-    }
     slot->key |= type;
 }
 
 static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
 {
-    if (slot->key)
-    {
-        slot->key &= (~type);
-        if (!slot->key)
-        {
-            slot->eg_gen = envelope_gen_num_release;
-            OPL3_EnvelopeUpdateRate(slot);
-        }
-    }
+    slot->key &= ~type;
 }
 
 //
@@ -543,9 +525,14 @@ static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
 
 static void OPL3_PhaseGenerate(opl3_slot *slot)
 {
+    opl3_chip *chip;
     Bit16u f_num;
     Bit32u basefreq;
+    Bit8u rm_xor, n_bit;
+    Bit32u noise;
+    Bit16u phase;
 
+    chip = slot->chip;
     f_num = slot->channel->f_num;
     if (slot->reg_vib)
     {
@@ -572,20 +559,58 @@ static void OPL3_PhaseGenerate(opl3_slot *slot)
         f_num += range;
     }
     basefreq = (f_num << slot->channel->block) >> 1;
-    slot->pg_phase += (basefreq * mt[slot->reg_mult]) >> 1;
-}
-
-//
-// Noise Generator
-//
-
-static void OPL3_NoiseGenerate(opl3_chip *chip)
-{
-    if (chip->noise & 0x01)
+    phase = (Bit16u)(slot->pg_phase >> 9);
+    if (slot->pg_reset)
     {
-        chip->noise ^= 0x800302;
+        slot->pg_phase = 0;
     }
-    chip->noise >>= 1;
+    slot->pg_phase += (basefreq * mt[slot->reg_mult]) >> 1;
+    // Rhythm mode
+    noise = chip->noise;
+    slot->pg_phase_out = phase;
+    if (slot->slot_num == 13) // hh
+    {
+        chip->rm_hh_bit2 = (phase >> 2) & 1;
+        chip->rm_hh_bit3 = (phase >> 3) & 1;
+        chip->rm_hh_bit7 = (phase >> 7) & 1;
+        chip->rm_hh_bit8 = (phase >> 8) & 1;
+    }
+    if (slot->slot_num == 17 && (chip->rhy & 0x20)) // tc
+    {
+        chip->rm_tc_bit3 = (phase >> 3) & 1;
+        chip->rm_tc_bit5 = (phase >> 5) & 1;
+    }
+    if (chip->rhy & 0x20)
+    {
+        rm_xor = (chip->rm_hh_bit2 ^ chip->rm_hh_bit7)
+               | (chip->rm_hh_bit3 ^ chip->rm_tc_bit5)
+               | (chip->rm_tc_bit3 ^ chip->rm_tc_bit5);
+        switch (slot->slot_num)
+        {
+        case 13: // hh
+            slot->pg_phase_out = rm_xor << 9;
+            if (rm_xor ^ (noise & 1))
+            {
+                slot->pg_phase_out |= 0xd0;
+            }
+            else
+            {
+                slot->pg_phase_out |= 0x34;
+            }
+            break;
+        case 16: // sd
+            slot->pg_phase_out = (chip->rm_hh_bit8 << 9)
+                               | ((chip->rm_hh_bit8 ^ (noise & 1)) << 8);
+            break;
+        case 17: // tc
+            slot->pg_phase_out = (rm_xor << 9) | 0x80;
+            break;
+        default:
+            break;
+        }
+    }
+    n_bit = ((noise >> 14) ^ noise) & 0x01;
+    chip->noise = (noise >> 1) | (n_bit << 22);
 }
 
 //
@@ -606,7 +631,6 @@ static void OPL3_SlotWrite20(opl3_slot *slot, Bit8u data)
     slot->reg_type = (data >> 5) & 0x01;
     slot->reg_ksr = (data >> 4) & 0x01;
     slot->reg_mult = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWrite40(opl3_slot *slot, Bit8u data)
@@ -620,7 +644,6 @@ static void OPL3_SlotWrite60(opl3_slot *slot, Bit8u data)
 {
     slot->reg_ar = (data >> 4) & 0x0f;
     slot->reg_dr = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
@@ -631,7 +654,6 @@ static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
         slot->reg_sl = 0x1f;
     }
     slot->reg_rr = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
@@ -643,19 +665,9 @@ static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
     }
 }
 
-static void OPL3_SlotGeneratePhase(opl3_slot *slot, Bit16u phase)
-{
-    slot->out = envelope_sin[slot->reg_wf](phase, slot->eg_out);
-}
-
 static void OPL3_SlotGenerate(opl3_slot *slot)
 {
-    OPL3_SlotGeneratePhase(slot, (Bit16u)(slot->pg_phase >> 9) + *slot->mod);
-}
-
-static void OPL3_SlotGenerateZM(opl3_slot *slot)
-{
-    OPL3_SlotGeneratePhase(slot, (Bit16u)(slot->pg_phase >> 9));
+    slot->out = envelope_sin[slot->reg_wf](slot->pg_phase_out + *slot->mod, slot->eg_out);
 }
 
 static void OPL3_SlotCalcFB(opl3_slot *slot)
@@ -707,6 +719,8 @@ static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
             chip->channel[chnum].chtype = ch_drum;
         }
         OPL3_ChannelSetupAlg(channel6);
+        OPL3_ChannelSetupAlg(channel7);
+        OPL3_ChannelSetupAlg(channel8);
         //hh
         if (chip->rhy & 0x01)
         {
@@ -778,16 +792,12 @@ static void OPL3_ChannelWriteA0(opl3_channel *channel, Bit8u data)
                  | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
     OPL3_EnvelopeUpdateKSL(channel->slots[0]);
     OPL3_EnvelopeUpdateKSL(channel->slots[1]);
-    OPL3_EnvelopeUpdateRate(channel->slots[0]);
-    OPL3_EnvelopeUpdateRate(channel->slots[1]);
     if (channel->chip->newm && channel->chtype == ch_4op)
     {
         channel->pair->f_num = channel->f_num;
         channel->pair->ksv = channel->ksv;
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[0]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[1]);
     }
 }
 
@@ -803,8 +813,6 @@ static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
                  | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
     OPL3_EnvelopeUpdateKSL(channel->slots[0]);
     OPL3_EnvelopeUpdateKSL(channel->slots[1]);
-    OPL3_EnvelopeUpdateRate(channel->slots[0]);
-    OPL3_EnvelopeUpdateRate(channel->slots[1]);
     if (channel->chip->newm && channel->chtype == ch_4op)
     {
         channel->pair->f_num = channel->f_num;
@@ -812,8 +820,6 @@ static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
         channel->pair->ksv = channel->ksv;
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[0]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[1]);
     }
 }
 
@@ -821,6 +827,12 @@ static void OPL3_ChannelSetupAlg(opl3_channel *channel)
 {
     if (channel->chtype == ch_drum)
     {
+        if (channel->ch_num == 7 || channel->ch_num == 8)
+        {
+            channel->slots[0]->mod = &channel->chip->zeromod;
+            channel->slots[1]->mod = &channel->chip->zeromod;
+            return;
+        }
         switch (channel->alg & 0x01)
         {
         case 0x00:
@@ -942,12 +954,12 @@ static void OPL3_ChannelWriteC0(opl3_channel *channel, Bit8u data)
     }
     if (channel->chip->newm)
     {
-        channel->cha = (data >> 4) & 0x01;
-        channel->chb = (data >> 5) & 0x01;
+        channel->cha = ((data >> 4) & 0x01) ? ~0 : 0;
+        channel->chb = ((data >> 5) & 0x01) ? ~0 : 0;
     }
     else
     {
-        channel->cha = channel->chb = 1;
+        channel->cha = channel->chb = (Bit16u)~0;
     }
     if (!channel->chip->stereoext)
     {
@@ -1050,62 +1062,6 @@ static Bit16s OPL3_ClipSample(Bit32s sample)
     return (Bit16s)sample;
 }
 
-static void OPL3_GenerateRhythm1(opl3_chip *chip)
-{
-    opl3_channel *channel6;
-    opl3_channel *channel7;
-    opl3_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    OPL3_SlotGenerate(channel6->slots[0]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04)
-             | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //hh
-    phase = (phasebit << 9)
-          | (0x34 << ((phasebit ^ (chip->noise & 0x01)) << 1));
-    OPL3_SlotGeneratePhase(channel7->slots[0], phase);
-    //tt
-    OPL3_SlotGenerateZM(channel8->slots[0]);
-}
-
-static void OPL3_GenerateRhythm2(opl3_chip *chip)
-{
-    opl3_channel *channel6;
-    opl3_channel *channel7;
-    opl3_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    OPL3_SlotGenerate(channel6->slots[1]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04)
-             | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //sd
-    phase = (0x100 << ((phase14 >> 8) & 0x01)) ^ ((chip->noise & 0x01) << 8);
-    OPL3_SlotGeneratePhase(channel7->slots[1], phase);
-    //tc
-    phase = 0x100 | (phasebit << 9);
-    OPL3_SlotGeneratePhase(channel8->slots[1], phase);
-}
-
 void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
 {
     Bit8u ii;
@@ -1115,30 +1071,12 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
 
     buf[1] = OPL3_ClipSample(chip->mixbuff[1]);
 
-    for (ii = 0; ii < 12; ii++)
+    for (ii = 0; ii < 15; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
-    }
-
-    for (ii = 12; ii < 15; ii++)
-    {
-        OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
-        OPL3_EnvelopeCalc(&chip->slot[ii]);
-    }
-
-    if (chip->rhy & 0x20)
-    {
-        OPL3_GenerateRhythm1(chip);
-    }
-    else
-    {
-        OPL3_SlotGenerate(&chip->slot[12]);
-        OPL3_SlotGenerate(&chip->slot[13]);
-        OPL3_SlotGenerate(&chip->slot[14]);
     }
 
     chip->mixbuff[0] = 0;
@@ -1155,19 +1093,9 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 15; ii < 18; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
-    }
-
-    if (chip->rhy & 0x20)
-    {
-        OPL3_GenerateRhythm2(chip);
-    }
-    else
-    {
-        OPL3_SlotGenerate(&chip->slot[15]);
-        OPL3_SlotGenerate(&chip->slot[16]);
-        OPL3_SlotGenerate(&chip->slot[17]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
+        OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
     buf[0] = OPL3_ClipSample(chip->mixbuff[0]);
@@ -1175,8 +1103,8 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 18; ii < 33; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
@@ -1194,12 +1122,10 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 33; ii < 36; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
     }
-    
-    OPL3_NoiseGenerate(chip);
 
     if ((chip->timer & 0x3f) == 0x3f)
     {
@@ -1220,6 +1146,39 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     }
 
     chip->timer++;
+
+    chip->eg_add = 0;
+    if (chip->eg_timer)
+    {
+        while (shift < 36 && ((chip->eg_timer >> shift) & 1) == 0)
+        {
+            shift++;
+        }
+        if (shift > 12)
+        {
+            chip->eg_add = 0;
+        }
+        else
+        {
+            chip->eg_add = shift + 1;
+        }
+    }
+
+    if (chip->eg_timerrem || chip->eg_state)
+    {
+        if (chip->eg_timer == 0xfffffffff)
+        {
+            chip->eg_timer = 0;
+            chip->eg_timerrem = 1;
+        }
+        else
+        {
+            chip->eg_timer++;
+            chip->eg_timerrem = 0;
+        }
+    }
+
+    chip->eg_state ^= 1;
 
     while (chip->writebuf[chip->writebuf_cur].time <= chip->writebuf_samplecnt)
     {
@@ -1259,6 +1218,7 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
 {
     Bit8u slotnum;
     Bit8u channum;
+    Bit32u i;
 
     memset(chip, 0, sizeof(opl3_chip));
     for (slotnum = 0; slotnum < 36; slotnum++)
@@ -1269,6 +1229,7 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
         chip->slot[slotnum].eg_out = 0x1ff;
         chip->slot[slotnum].eg_gen = envelope_gen_num_release;
         chip->slot[slotnum].trem = (Bit8u*)&chip->zeromod;
+        chip->slot[slotnum].slot_num = slotnum;
     }
     for (channum = 0; channum < 18; channum++)
     {
@@ -1290,20 +1251,21 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
         chip->channel[channum].out[2] = &chip->zeromod;
         chip->channel[channum].out[3] = &chip->zeromod;
         chip->channel[channum].chtype = ch_2op;
-        chip->channel[channum].cha = ~0;
-        chip->channel[channum].chb = ~0;
+        chip->channel[channum].cha = 0xffff;
+        chip->channel[channum].chb = 0xffff;
+        chip->channel[channum].ch_num = channum;
         chip->channel[channum].leftpan = 0x10000;
         chip->channel[channum].rightpan = 0x10000;
         OPL3_ChannelSetupAlg(&chip->channel[channum]);
     }
-    chip->noise = 0x306600;
+    chip->noise = 1;
     chip->rateratio = (samplerate << RSM_FRAC) / 49716;
     chip->tremoloshift = 4;
     chip->vibshift = 1;
 
     if (!panpot_lut_build)
     {
-        for (int i = 0; i < 256; i++)
+        for (i = 0; i < 256; i++)
         {
             panpot_lut[i] = (Bit32u)(sin(i * M_PI / 512.0) * 0x10000);
         }
@@ -1315,11 +1277,6 @@ void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
 {
     Bit8u high = (reg >> 8) & 0x01;
     Bit8u regm = reg & 0xff;
-    if (!chip->newm && reg != 0x105)
-    {
-        high = 0x00;
-    }
-
     switch (regm & 0xf0)
     {
     case 0x00:
@@ -1425,7 +1382,6 @@ void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
 void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v)
 {
     Bit64u time1, time2;
-    reg &= 0x1ff;
 
     if (chip->writebuf[chip->writebuf_last].reg & 0x200)
     {
@@ -1435,6 +1391,7 @@ void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v)
         chip->writebuf_cur = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
         chip->writebuf_samplecnt = chip->writebuf[chip->writebuf_last].time;
     }
+
     chip->writebuf[chip->writebuf_last].reg = reg | 0x200;
     chip->writebuf[chip->writebuf_last].data = v;
     time1 = chip->writebuf_lasttime + OPL_WRITEBUF_DELAY;
@@ -1456,7 +1413,14 @@ void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
 
     for(i = 0; i < numsamples; i++)
     {
-        OPL3_GenerateResampled(chip, sndptr);
+        if (chip->rateratio == 1 << RSM_FRAC)
+        {
+            OPL3_Generate(chip, sndptr);
+        }
+        else
+        {
+            OPL3_GenerateResampled(chip, sndptr);
+        }
         sndptr += 2;
     }
 }

--- a/doomopl_ext/driver/fmopl3lib/opl3.cpp
+++ b/doomopl_ext/driver/fmopl3lib/opl3.cpp
@@ -1413,14 +1413,7 @@ void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
 
     for(i = 0; i < numsamples; i++)
     {
-        if (chip->rateratio == 1 << RSM_FRAC)
-        {
-            OPL3_Generate(chip, sndptr);
-        }
-        else
-        {
-            OPL3_GenerateResampled(chip, sndptr);
-        }
+        OPL3_GenerateResampled(chip, sndptr);
         sndptr += 2;
     }
 }

--- a/doomopl_ext/driver/fmopl3lib/opl3.h
+++ b/doomopl_ext/driver/fmopl3lib/opl3.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2017 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,22 +15,24 @@
 //  Nuked OPL3 emulator.
 //  Thanks:
 //      MAME Development Team(Jarek Burczynski, Tatsuyuki Satoh):
-//          Feedback calculation information.
+//          Feedback and Rhythm part calculation information.
 //      forums.submarine.org.uk(carbon14, opl3):
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.7.4
+// version: 1.8
 //
 
 #ifndef OPL_OPL3_H
 #define OPL_OPL3_H
 
-#include <stdint.h>
+#include <inttypes.h>
 
 #define OPL_WRITEBUF_SIZE   1024
-#define OPL_WRITEBUF_DELAY  1
+#define OPL_WRITEBUF_DELAY  2
 
 typedef uintptr_t       Bitu;
 typedef intptr_t        Bits;
@@ -73,7 +75,10 @@ struct _opl3_slot {
     Bit8u reg_rr;
     Bit8u reg_wf;
     Bit8u key;
+    Bit32u pg_reset;
     Bit32u pg_phase;
+    Bit16u pg_phase_out;
+    Bit8u slot_num;
 };
 
 struct _opl3_channel {
@@ -89,6 +94,7 @@ struct _opl3_channel {
     Bit8u alg;
     Bit8u ksv;
     Bit16u cha, chb;
+    Bit8u ch_num;
     Bit32s leftpan;
     Bit32s rightpan;
 };
@@ -103,6 +109,10 @@ struct _opl3_chip {
     opl3_channel channel[18];
     opl3_slot slot[36];
     Bit16u timer;
+    Bit64u eg_timer;
+    Bit8u eg_timerrem;
+    Bit8u eg_state;
+    Bit8u eg_add;
     Bit8u newm;
     Bit8u nts;
     Bit8u rhy;
@@ -114,7 +124,12 @@ struct _opl3_chip {
     Bit32u noise;
     Bit16s zeromod;
     Bit32s mixbuff[2];
-
+    Bit8u rm_hh_bit2;
+    Bit8u rm_hh_bit3;
+    Bit8u rm_hh_bit7;
+    Bit8u rm_hh_bit8;
+    Bit8u rm_tc_bit3;
+    Bit8u rm_tc_bit5;
     Bit8u stereoext;
     //OPL3L
     Bit32s rateratio;
@@ -135,4 +150,7 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate);
 void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v);
 void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v);
 void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
+#endif
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
 #endif

--- a/doomopl_ext/driver/fmopl3lib/opl3class.h
+++ b/doomopl_ext/driver/fmopl3lib/opl3class.h
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 //
 
-#include "..\interface.h"
+#include "../interface.h"
 #include "opl3.h"
 
 

--- a/opl3windows/driver/fmopl3lib/opl3.cpp
+++ b/opl3windows/driver/fmopl3lib/opl3.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2016 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -20,8 +20,10 @@
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.7.1
+// version: 1.8
 //
 
 #include <stdio.h>
@@ -92,41 +94,41 @@ static const Bit16u logsinrom[256] = {
 //
 
 static const Bit16u exprom[256] = {
-    0x000, 0x003, 0x006, 0x008, 0x00b, 0x00e, 0x011, 0x014,
-    0x016, 0x019, 0x01c, 0x01f, 0x022, 0x025, 0x028, 0x02a,
-    0x02d, 0x030, 0x033, 0x036, 0x039, 0x03c, 0x03f, 0x042,
-    0x045, 0x048, 0x04b, 0x04e, 0x051, 0x054, 0x057, 0x05a,
-    0x05d, 0x060, 0x063, 0x066, 0x069, 0x06c, 0x06f, 0x072,
-    0x075, 0x078, 0x07b, 0x07e, 0x082, 0x085, 0x088, 0x08b,
-    0x08e, 0x091, 0x094, 0x098, 0x09b, 0x09e, 0x0a1, 0x0a4,
-    0x0a8, 0x0ab, 0x0ae, 0x0b1, 0x0b5, 0x0b8, 0x0bb, 0x0be,
-    0x0c2, 0x0c5, 0x0c8, 0x0cc, 0x0cf, 0x0d2, 0x0d6, 0x0d9,
-    0x0dc, 0x0e0, 0x0e3, 0x0e7, 0x0ea, 0x0ed, 0x0f1, 0x0f4,
-    0x0f8, 0x0fb, 0x0ff, 0x102, 0x106, 0x109, 0x10c, 0x110,
-    0x114, 0x117, 0x11b, 0x11e, 0x122, 0x125, 0x129, 0x12c,
-    0x130, 0x134, 0x137, 0x13b, 0x13e, 0x142, 0x146, 0x149,
-    0x14d, 0x151, 0x154, 0x158, 0x15c, 0x160, 0x163, 0x167,
-    0x16b, 0x16f, 0x172, 0x176, 0x17a, 0x17e, 0x181, 0x185,
-    0x189, 0x18d, 0x191, 0x195, 0x199, 0x19c, 0x1a0, 0x1a4,
-    0x1a8, 0x1ac, 0x1b0, 0x1b4, 0x1b8, 0x1bc, 0x1c0, 0x1c4,
-    0x1c8, 0x1cc, 0x1d0, 0x1d4, 0x1d8, 0x1dc, 0x1e0, 0x1e4,
-    0x1e8, 0x1ec, 0x1f0, 0x1f5, 0x1f9, 0x1fd, 0x201, 0x205,
-    0x209, 0x20e, 0x212, 0x216, 0x21a, 0x21e, 0x223, 0x227,
-    0x22b, 0x230, 0x234, 0x238, 0x23c, 0x241, 0x245, 0x249,
-    0x24e, 0x252, 0x257, 0x25b, 0x25f, 0x264, 0x268, 0x26d,
-    0x271, 0x276, 0x27a, 0x27f, 0x283, 0x288, 0x28c, 0x291,
-    0x295, 0x29a, 0x29e, 0x2a3, 0x2a8, 0x2ac, 0x2b1, 0x2b5,
-    0x2ba, 0x2bf, 0x2c4, 0x2c8, 0x2cd, 0x2d2, 0x2d6, 0x2db,
-    0x2e0, 0x2e5, 0x2e9, 0x2ee, 0x2f3, 0x2f8, 0x2fd, 0x302,
-    0x306, 0x30b, 0x310, 0x315, 0x31a, 0x31f, 0x324, 0x329,
-    0x32e, 0x333, 0x338, 0x33d, 0x342, 0x347, 0x34c, 0x351,
-    0x356, 0x35b, 0x360, 0x365, 0x36a, 0x370, 0x375, 0x37a,
-    0x37f, 0x384, 0x38a, 0x38f, 0x394, 0x399, 0x39f, 0x3a4,
-    0x3a9, 0x3ae, 0x3b4, 0x3b9, 0x3bf, 0x3c4, 0x3c9, 0x3cf,
-    0x3d4, 0x3da, 0x3df, 0x3e4, 0x3ea, 0x3ef, 0x3f5, 0x3fa
+    0x7fa, 0x7f5, 0x7ef, 0x7ea, 0x7e4, 0x7df, 0x7da, 0x7d4,
+    0x7cf, 0x7c9, 0x7c4, 0x7bf, 0x7b9, 0x7b4, 0x7ae, 0x7a9,
+    0x7a4, 0x79f, 0x799, 0x794, 0x78f, 0x78a, 0x784, 0x77f,
+    0x77a, 0x775, 0x770, 0x76a, 0x765, 0x760, 0x75b, 0x756,
+    0x751, 0x74c, 0x747, 0x742, 0x73d, 0x738, 0x733, 0x72e,
+    0x729, 0x724, 0x71f, 0x71a, 0x715, 0x710, 0x70b, 0x706,
+    0x702, 0x6fd, 0x6f8, 0x6f3, 0x6ee, 0x6e9, 0x6e5, 0x6e0,
+    0x6db, 0x6d6, 0x6d2, 0x6cd, 0x6c8, 0x6c4, 0x6bf, 0x6ba,
+    0x6b5, 0x6b1, 0x6ac, 0x6a8, 0x6a3, 0x69e, 0x69a, 0x695,
+    0x691, 0x68c, 0x688, 0x683, 0x67f, 0x67a, 0x676, 0x671,
+    0x66d, 0x668, 0x664, 0x65f, 0x65b, 0x657, 0x652, 0x64e,
+    0x649, 0x645, 0x641, 0x63c, 0x638, 0x634, 0x630, 0x62b,
+    0x627, 0x623, 0x61e, 0x61a, 0x616, 0x612, 0x60e, 0x609,
+    0x605, 0x601, 0x5fd, 0x5f9, 0x5f5, 0x5f0, 0x5ec, 0x5e8,
+    0x5e4, 0x5e0, 0x5dc, 0x5d8, 0x5d4, 0x5d0, 0x5cc, 0x5c8,
+    0x5c4, 0x5c0, 0x5bc, 0x5b8, 0x5b4, 0x5b0, 0x5ac, 0x5a8,
+    0x5a4, 0x5a0, 0x59c, 0x599, 0x595, 0x591, 0x58d, 0x589,
+    0x585, 0x581, 0x57e, 0x57a, 0x576, 0x572, 0x56f, 0x56b,
+    0x567, 0x563, 0x560, 0x55c, 0x558, 0x554, 0x551, 0x54d,
+    0x549, 0x546, 0x542, 0x53e, 0x53b, 0x537, 0x534, 0x530,
+    0x52c, 0x529, 0x525, 0x522, 0x51e, 0x51b, 0x517, 0x514,
+    0x510, 0x50c, 0x509, 0x506, 0x502, 0x4ff, 0x4fb, 0x4f8,
+    0x4f4, 0x4f1, 0x4ed, 0x4ea, 0x4e7, 0x4e3, 0x4e0, 0x4dc,
+    0x4d9, 0x4d6, 0x4d2, 0x4cf, 0x4cc, 0x4c8, 0x4c5, 0x4c2,
+    0x4be, 0x4bb, 0x4b8, 0x4b5, 0x4b1, 0x4ae, 0x4ab, 0x4a8,
+    0x4a4, 0x4a1, 0x49e, 0x49b, 0x498, 0x494, 0x491, 0x48e,
+    0x48b, 0x488, 0x485, 0x482, 0x47e, 0x47b, 0x478, 0x475,
+    0x472, 0x46f, 0x46c, 0x469, 0x466, 0x463, 0x460, 0x45d,
+    0x45a, 0x457, 0x454, 0x451, 0x44e, 0x44b, 0x448, 0x445,
+    0x442, 0x43f, 0x43c, 0x439, 0x436, 0x433, 0x430, 0x42d,
+    0x42a, 0x428, 0x425, 0x422, 0x41f, 0x41c, 0x419, 0x416,
+    0x414, 0x411, 0x40e, 0x40b, 0x408, 0x406, 0x403, 0x400
 };
 
-// 
+//
 // freq mult table multiplied by 2
 //
 // 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 12, 12, 15, 15
@@ -152,33 +154,11 @@ static const Bit8u kslshift[4] = {
 // envelope generator constants
 //
 
-static const Bit8u eg_incstep[3][4][8] = {
-    {
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 },
-        { 0, 0, 0, 0, 0, 0, 0, 0 }
-    },
-    {
-        { 0, 1, 0, 1, 0, 1, 0, 1 },
-        { 0, 1, 0, 1, 1, 1, 0, 1 },
-        { 0, 1, 1, 1, 0, 1, 1, 1 },
-        { 0, 1, 1, 1, 1, 1, 1, 1 }
-    },
-    {
-        { 1, 1, 1, 1, 1, 1, 1, 1 },
-        { 2, 2, 1, 1, 1, 1, 1, 1 },
-        { 2, 2, 1, 1, 2, 2, 1, 1 },
-        { 2, 2, 2, 2, 2, 2, 1, 1 }
-    }
-};
-
-static const Bit8u eg_incdesc[16] = {
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2
-};
-
-static const Bit8s eg_incsh[16] = {
-    0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, -1, -2
+static const Bit8u eg_incstep[4][4] = {
+    { 0, 0, 0, 0 },
+    { 1, 0, 0, 0 },
+    { 1, 0, 1, 0 },
+    { 1, 1, 1, 0 }
 };
 
 //
@@ -207,7 +187,7 @@ static Bit16s OPL3_EnvelopeCalcExp(Bit32u level)
     {
         level = 0x1fff;
     }
-    return ((exprom[(level & 0xff) ^ 0xff] | 0x400) << 1) >> (level >> 8);
+    return (exprom[level & 0xff] << 1) >> (level >> 8);
 }
 
 static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
@@ -217,7 +197,7 @@ static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     if (phase & 0x100)
     {
@@ -286,7 +266,7 @@ static Bit16s OPL3_EnvelopeCalcSin4(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if ((phase & 0x300) == 0x100)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     if (phase & 0x200)
     {
@@ -328,7 +308,7 @@ static Bit16s OPL3_EnvelopeCalcSin6(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
     }
     return OPL3_EnvelopeCalcExp(envelope << 3) ^ neg;
 }
@@ -340,7 +320,7 @@ static Bit16s OPL3_EnvelopeCalcSin7(Bit16u phase, Bit16u envelope)
     phase &= 0x3ff;
     if (phase & 0x200)
     {
-        neg = ~0;
+        neg = 0xffff;
         phase = (phase & 0x1ff) ^ 0x1ff;
     }
     out = phase << 3;
@@ -358,44 +338,13 @@ static const envelope_sinfunc envelope_sin[8] = {
     OPL3_EnvelopeCalcSin7
 };
 
-static void OPL3_EnvelopeGenOff(opl3_slot *slot);
-static void OPL3_EnvelopeGenAttack(opl3_slot *slot);
-static void OPL3_EnvelopeGenDecay(opl3_slot *slot);
-static void OPL3_EnvelopeGenSustain(opl3_slot *slot);
-static void OPL3_EnvelopeGenRelease(opl3_slot *slot);
-
-envelope_genfunc envelope_gen[5] = {
-    OPL3_EnvelopeGenOff,
-    OPL3_EnvelopeGenAttack,
-    OPL3_EnvelopeGenDecay,
-    OPL3_EnvelopeGenSustain,
-    OPL3_EnvelopeGenRelease
-};
-
 enum envelope_gen_num
 {
-    envelope_gen_num_off = 0,
-    envelope_gen_num_attack = 1,
-    envelope_gen_num_decay = 2,
-    envelope_gen_num_sustain = 3,
-    envelope_gen_num_release = 4
+    envelope_gen_num_attack = 0,
+    envelope_gen_num_decay = 1,
+    envelope_gen_num_sustain = 2,
+    envelope_gen_num_release = 3
 };
-
-static Bit8u OPL3_EnvelopeCalcRate(opl3_slot *slot, Bit8u reg_rate)
-{
-    Bit8u rate;
-    if (reg_rate == 0x00)
-    {
-        return 0x00;
-    }
-    rate = (reg_rate << 2)
-         + (slot->reg_ksr ? slot->channel->ksv : (slot->channel->ksv >> 2));
-    if (rate > 0x3c)
-    {
-        rate = 0x3c;
-    }
-    return rate;
-}
 
 static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
 {
@@ -408,128 +357,161 @@ static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
     slot->eg_ksl = (Bit8u)ksl;
 }
 
-static void OPL3_EnvelopeUpdateRate(opl3_slot *slot)
-{
-    switch (slot->eg_gen)
-    {
-    case envelope_gen_num_off:
-    case envelope_gen_num_attack:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_ar);
-        break;
-    case envelope_gen_num_decay:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_dr);
-        break;
-    case envelope_gen_num_sustain:
-    case envelope_gen_num_release:
-        slot->eg_rate = OPL3_EnvelopeCalcRate(slot, slot->reg_rr);
-        break;
-    }
-}
-
-static void OPL3_EnvelopeGenOff(opl3_slot *slot)
-{
-    slot->eg_rout = 0x1ff;
-}
-
-static void OPL3_EnvelopeGenAttack(opl3_slot *slot)
-{
-    if (slot->eg_rout == 0x00)
-    {
-        slot->eg_gen = envelope_gen_num_decay;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += ((~slot->eg_rout) * slot->eg_inc) >> 3;
-    if (slot->eg_rout < 0x00)
-    {
-        slot->eg_rout = 0x00;
-    }
-}
-
-static void OPL3_EnvelopeGenDecay(opl3_slot *slot)
-{
-    if (slot->eg_rout >= slot->reg_sl << 4)
-    {
-        slot->eg_gen = envelope_gen_num_sustain;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
-static void OPL3_EnvelopeGenSustain(opl3_slot *slot)
-{
-    if (!slot->reg_type)
-    {
-        OPL3_EnvelopeGenRelease(slot);
-    }
-}
-
-static void OPL3_EnvelopeGenRelease(opl3_slot *slot)
-{
-    if (slot->eg_rout >= 0x1ff)
-    {
-        slot->eg_gen = envelope_gen_num_off;
-        slot->eg_rout = 0x1ff;
-        OPL3_EnvelopeUpdateRate(slot);
-        return;
-    }
-    slot->eg_rout += slot->eg_inc;
-}
-
 static void OPL3_EnvelopeCalc(opl3_slot *slot)
 {
-    Bit8u rate_h, rate_l;
-    Bit8u inc = 0;
-    rate_h = slot->eg_rate >> 2;
-    rate_l = slot->eg_rate & 3;
-    if (eg_incsh[rate_h] > 0)
+    Bit8u nonzero;
+    Bit8u rate;
+    Bit8u rate_hi;
+    Bit8u rate_lo;
+    Bit8u reg_rate = 0;
+    Bit8u ks;
+    Bit8u eg_shift, shift;
+    Bit16u eg_rout;
+    Bit16s eg_inc;
+    Bit8u eg_off;
+    Bit8u reset = 0;
+    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
+                 + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
+    if (slot->key && slot->eg_gen == envelope_gen_num_release)
     {
-        if ((slot->chip->timer & ((1 << eg_incsh[rate_h]) - 1)) == 0)
-        {
-            inc = eg_incstep[eg_incdesc[rate_h]][rate_l]
-                            [((slot->chip->timer)>> eg_incsh[rate_h]) & 0x07];
-        }
+        reset = 1;
+        reg_rate = slot->reg_ar;
     }
     else
     {
-        inc = eg_incstep[eg_incdesc[rate_h]][rate_l]
-                        [slot->chip->timer & 0x07] << (-eg_incsh[rate_h]);
+        switch (slot->eg_gen)
+        {
+        case envelope_gen_num_attack:
+            reg_rate = slot->reg_ar;
+            break;
+        case envelope_gen_num_decay:
+            reg_rate = slot->reg_dr;
+            break;
+        case envelope_gen_num_sustain:
+            if (!slot->reg_type)
+            {
+                reg_rate = slot->reg_rr;
+            }
+            break;
+        case envelope_gen_num_release:
+            reg_rate = slot->reg_rr;
+            break;
+        }
     }
-    slot->eg_inc = inc;
-    slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
-                 + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
-    envelope_gen[slot->eg_gen](slot);
+    slot->pg_reset = reset;
+    ks = slot->channel->ksv >> ((slot->reg_ksr ^ 1) << 1);
+    nonzero = (reg_rate != 0);
+    rate = ks + (reg_rate << 2);
+    rate_hi = rate >> 2;
+    rate_lo = rate & 0x03;
+    if (rate_hi & 0x10)
+    {
+        rate_hi = 0x0f;
+    }
+    eg_shift = rate_hi + slot->chip->eg_add;
+    shift = 0;
+    if (nonzero)
+    {
+        if (rate_hi < 12)
+        {
+            if (slot->chip->eg_state)
+            {
+                switch (eg_shift)
+                {
+                case 12:
+                    shift = 1;
+                    break;
+                case 13:
+                    shift = (rate_lo >> 1) & 0x01;
+                    break;
+                case 14:
+                    shift = rate_lo & 0x01;
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+        else
+        {
+            shift = (rate_hi & 0x03) + eg_incstep[rate_lo][slot->chip->timer & 0x03];
+            if (shift & 0x04)
+            {
+                shift = 0x03;
+            }
+            if (!shift)
+            {
+                shift = slot->chip->eg_state;
+            }
+        }
+    }
+    eg_rout = slot->eg_rout;
+    eg_inc = 0;
+    eg_off = 0;
+    // Instant attack
+    if (reset && rate_hi == 0x0f)
+    {
+        eg_rout = 0x00;
+    }
+    // Envelope off
+    if ((slot->eg_rout & 0x1f8) == 0x1f8)
+    {
+        eg_off = 1;
+    }
+    if (slot->eg_gen != envelope_gen_num_attack && !reset && eg_off)
+    {
+        eg_rout = 0x1ff;
+    }
+    switch (slot->eg_gen)
+    {
+    case envelope_gen_num_attack:
+        if (!slot->eg_rout)
+        {
+            slot->eg_gen = envelope_gen_num_decay;
+        }
+        else if (slot->key && shift > 0 && rate_hi != 0x0f)
+        {
+            eg_inc = ((~slot->eg_rout) << shift) >> 4;
+        }
+        break;
+    case envelope_gen_num_decay:
+        if ((slot->eg_rout >> 4) == slot->reg_sl)
+        {
+            slot->eg_gen = envelope_gen_num_sustain;
+        }
+        else if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
+        break;
+    case envelope_gen_num_sustain:
+    case envelope_gen_num_release:
+        if (!eg_off && !reset && shift > 0)
+        {
+            eg_inc = 1 << (shift - 1);
+        }
+        break;
+    }
+    slot->eg_rout = (eg_rout + eg_inc) & 0x1ff;
+    // Key off
+    if (reset)
+    {
+        slot->eg_gen = envelope_gen_num_attack;
+    }
+    if (!slot->key)
+    {
+        slot->eg_gen = envelope_gen_num_release;
+    }
 }
 
 static void OPL3_EnvelopeKeyOn(opl3_slot *slot, Bit8u type)
 {
-    if (!slot->key)
-    {
-        slot->eg_gen = envelope_gen_num_attack;
-        OPL3_EnvelopeUpdateRate(slot);
-        if ((slot->eg_rate >> 2) == 0x0f)
-        {
-            slot->eg_gen = envelope_gen_num_decay;
-            OPL3_EnvelopeUpdateRate(slot);
-            slot->eg_rout = 0x00;
-        }
-        slot->pg_phase = 0x00;
-    }
     slot->key |= type;
 }
 
 static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
 {
-    if (slot->key)
-    {
-        slot->key &= (~type);
-        if (!slot->key)
-        {
-            slot->eg_gen = envelope_gen_num_release;
-            OPL3_EnvelopeUpdateRate(slot);
-        }
-    }
+    slot->key &= ~type;
 }
 
 //
@@ -538,9 +520,14 @@ static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
 
 static void OPL3_PhaseGenerate(opl3_slot *slot)
 {
+    opl3_chip *chip;
     Bit16u f_num;
     Bit32u basefreq;
+    Bit8u rm_xor, n_bit;
+    Bit32u noise;
+    Bit16u phase;
 
+    chip = slot->chip;
     f_num = slot->channel->f_num;
     if (slot->reg_vib)
     {
@@ -567,20 +554,58 @@ static void OPL3_PhaseGenerate(opl3_slot *slot)
         f_num += range;
     }
     basefreq = (f_num << slot->channel->block) >> 1;
-    slot->pg_phase += (basefreq * mt[slot->reg_mult]) >> 1;
-}
-
-//
-// Noise Generator
-//
-
-static void OPL3_NoiseGenerate(opl3_chip *chip)
-{
-    if (chip->noise & 0x01)
+    phase = (Bit16u)(slot->pg_phase >> 9);
+    if (slot->pg_reset)
     {
-        chip->noise ^= 0x800302;
+        slot->pg_phase = 0;
     }
-    chip->noise >>= 1;
+    slot->pg_phase += (basefreq * mt[slot->reg_mult]) >> 1;
+    // Rhythm mode
+    noise = chip->noise;
+    slot->pg_phase_out = phase;
+    if (slot->slot_num == 13) // hh
+    {
+        chip->rm_hh_bit2 = (phase >> 2) & 1;
+        chip->rm_hh_bit3 = (phase >> 3) & 1;
+        chip->rm_hh_bit7 = (phase >> 7) & 1;
+        chip->rm_hh_bit8 = (phase >> 8) & 1;
+    }
+    if (slot->slot_num == 17 && (chip->rhy & 0x20)) // tc
+    {
+        chip->rm_tc_bit3 = (phase >> 3) & 1;
+        chip->rm_tc_bit5 = (phase >> 5) & 1;
+    }
+    if (chip->rhy & 0x20)
+    {
+        rm_xor = (chip->rm_hh_bit2 ^ chip->rm_hh_bit7)
+               | (chip->rm_hh_bit3 ^ chip->rm_tc_bit5)
+               | (chip->rm_tc_bit3 ^ chip->rm_tc_bit5);
+        switch (slot->slot_num)
+        {
+        case 13: // hh
+            slot->pg_phase_out = rm_xor << 9;
+            if (rm_xor ^ (noise & 1))
+            {
+                slot->pg_phase_out |= 0xd0;
+            }
+            else
+            {
+                slot->pg_phase_out |= 0x34;
+            }
+            break;
+        case 16: // sd
+            slot->pg_phase_out = (chip->rm_hh_bit8 << 9)
+                               | ((chip->rm_hh_bit8 ^ (noise & 1)) << 8);
+            break;
+        case 17: // tc
+            slot->pg_phase_out = (rm_xor << 9) | 0x80;
+            break;
+        default:
+            break;
+        }
+    }
+    n_bit = ((noise >> 14) ^ noise) & 0x01;
+    chip->noise = (noise >> 1) | (n_bit << 22);
 }
 
 //
@@ -601,7 +626,6 @@ static void OPL3_SlotWrite20(opl3_slot *slot, Bit8u data)
     slot->reg_type = (data >> 5) & 0x01;
     slot->reg_ksr = (data >> 4) & 0x01;
     slot->reg_mult = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWrite40(opl3_slot *slot, Bit8u data)
@@ -615,7 +639,6 @@ static void OPL3_SlotWrite60(opl3_slot *slot, Bit8u data)
 {
     slot->reg_ar = (data >> 4) & 0x0f;
     slot->reg_dr = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
@@ -626,7 +649,6 @@ static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
         slot->reg_sl = 0x1f;
     }
     slot->reg_rr = data & 0x0f;
-    OPL3_EnvelopeUpdateRate(slot);
 }
 
 static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
@@ -638,19 +660,9 @@ static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
     }
 }
 
-static void OPL3_SlotGeneratePhase(opl3_slot *slot, Bit16u phase)
-{
-    slot->out = envelope_sin[slot->reg_wf](phase, slot->eg_out);
-}
-
 static void OPL3_SlotGenerate(opl3_slot *slot)
 {
-    OPL3_SlotGeneratePhase(slot, (Bit16u)(slot->pg_phase >> 9) + *slot->mod);
-}
-
-static void OPL3_SlotGenerateZM(opl3_slot *slot)
-{
-    OPL3_SlotGeneratePhase(slot, (Bit16u)(slot->pg_phase >> 9));
+    slot->out = envelope_sin[slot->reg_wf](slot->pg_phase_out + *slot->mod, slot->eg_out);
 }
 
 static void OPL3_SlotCalcFB(opl3_slot *slot)
@@ -702,6 +714,8 @@ static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
             chip->channel[chnum].chtype = ch_drum;
         }
         OPL3_ChannelSetupAlg(channel6);
+        OPL3_ChannelSetupAlg(channel7);
+        OPL3_ChannelSetupAlg(channel8);
         //hh
         if (chip->rhy & 0x01)
         {
@@ -756,6 +770,8 @@ static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
         {
             chip->channel[chnum].chtype = ch_2op;
             OPL3_ChannelSetupAlg(&chip->channel[chnum]);
+            OPL3_EnvelopeKeyOff(chip->channel[chnum].slots[0], egk_drum);
+            OPL3_EnvelopeKeyOff(chip->channel[chnum].slots[1], egk_drum);
         }
     }
 }
@@ -771,16 +787,12 @@ static void OPL3_ChannelWriteA0(opl3_channel *channel, Bit8u data)
                  | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
     OPL3_EnvelopeUpdateKSL(channel->slots[0]);
     OPL3_EnvelopeUpdateKSL(channel->slots[1]);
-    OPL3_EnvelopeUpdateRate(channel->slots[0]);
-    OPL3_EnvelopeUpdateRate(channel->slots[1]);
     if (channel->chip->newm && channel->chtype == ch_4op)
     {
         channel->pair->f_num = channel->f_num;
         channel->pair->ksv = channel->ksv;
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[0]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[1]);
     }
 }
 
@@ -796,8 +808,6 @@ static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
                  | ((channel->f_num >> (0x09 - channel->chip->nts)) & 0x01);
     OPL3_EnvelopeUpdateKSL(channel->slots[0]);
     OPL3_EnvelopeUpdateKSL(channel->slots[1]);
-    OPL3_EnvelopeUpdateRate(channel->slots[0]);
-    OPL3_EnvelopeUpdateRate(channel->slots[1]);
     if (channel->chip->newm && channel->chtype == ch_4op)
     {
         channel->pair->f_num = channel->f_num;
@@ -805,8 +815,6 @@ static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
         channel->pair->ksv = channel->ksv;
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[0]);
         OPL3_EnvelopeUpdateKSL(channel->pair->slots[1]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[0]);
-        OPL3_EnvelopeUpdateRate(channel->pair->slots[1]);
     }
 }
 
@@ -814,6 +822,12 @@ static void OPL3_ChannelSetupAlg(opl3_channel *channel)
 {
     if (channel->chtype == ch_drum)
     {
+        if (channel->ch_num == 7 || channel->ch_num == 8)
+        {
+            channel->slots[0]->mod = &channel->chip->zeromod;
+            channel->slots[1]->mod = &channel->chip->zeromod;
+            return;
+        }
         switch (channel->alg & 0x01)
         {
         case 0x00:
@@ -940,7 +954,7 @@ static void OPL3_ChannelWriteC0(opl3_channel *channel, Bit8u data)
     }
     else
     {
-        channel->cha = channel->chb = ~0;
+        channel->cha = channel->chb = (Bit16u)~0;
     }
 }
 
@@ -1029,94 +1043,21 @@ static Bit16s OPL3_ClipSample(Bit32s sample)
     return (Bit16s)sample;
 }
 
-static void OPL3_GenerateRhythm1(opl3_chip *chip)
-{
-    opl3_channel *channel6;
-    opl3_channel *channel7;
-    opl3_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    OPL3_SlotGenerate(channel6->slots[0]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04)
-             | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //hh
-    phase = (phasebit << 9)
-          | (0x34 << ((phasebit ^ (chip->noise & 0x01) << 1)));
-    OPL3_SlotGeneratePhase(channel7->slots[0], phase);
-    //tt
-    OPL3_SlotGenerateZM(channel8->slots[0]);
-}
-
-static void OPL3_GenerateRhythm2(opl3_chip *chip)
-{
-    opl3_channel *channel6;
-    opl3_channel *channel7;
-    opl3_channel *channel8;
-    Bit16u phase14;
-    Bit16u phase17;
-    Bit16u phase;
-    Bit16u phasebit;
-
-    channel6 = &chip->channel[6];
-    channel7 = &chip->channel[7];
-    channel8 = &chip->channel[8];
-    OPL3_SlotGenerate(channel6->slots[1]);
-    phase14 = (channel7->slots[0]->pg_phase >> 9) & 0x3ff;
-    phase17 = (channel8->slots[1]->pg_phase >> 9) & 0x3ff;
-    phase = 0x00;
-    //hh tc phase bit
-    phasebit = ((phase14 & 0x08) | (((phase14 >> 5) ^ phase14) & 0x04)
-             | (((phase17 >> 2) ^ phase17) & 0x08)) ? 0x01 : 0x00;
-    //sd
-    phase = (0x100 << ((phase14 >> 8) & 0x01)) ^ ((chip->noise & 0x01) << 8);
-    OPL3_SlotGeneratePhase(channel7->slots[1], phase);
-    //tc
-    phase = 0x100 | (phasebit << 9);
-    OPL3_SlotGeneratePhase(channel8->slots[1], phase);
-}
-
 void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
 {
     Bit8u ii;
     Bit8u jj;
     Bit16s accm;
+    Bit8u shift = 0;
 
     buf[1] = OPL3_ClipSample(chip->mixbuff[1]);
 
-    for (ii = 0; ii < 12; ii++)
+    for (ii = 0; ii < 15; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
-    }
-
-    for (ii = 12; ii < 15; ii++)
-    {
-        OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
-        OPL3_EnvelopeCalc(&chip->slot[ii]);
-    }
-
-    if (chip->rhy & 0x20)
-    {
-        OPL3_GenerateRhythm1(chip);
-    }
-    else
-    {
-        OPL3_SlotGenerate(&chip->slot[12]);
-        OPL3_SlotGenerate(&chip->slot[13]);
-        OPL3_SlotGenerate(&chip->slot[14]);
     }
 
     chip->mixbuff[0] = 0;
@@ -1133,19 +1074,9 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 15; ii < 18; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
-    }
-
-    if (chip->rhy & 0x20)
-    {
-        OPL3_GenerateRhythm2(chip);
-    }
-    else
-    {
-        OPL3_SlotGenerate(&chip->slot[15]);
-        OPL3_SlotGenerate(&chip->slot[16]);
-        OPL3_SlotGenerate(&chip->slot[17]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
+        OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
     buf[0] = OPL3_ClipSample(chip->mixbuff[0]);
@@ -1153,8 +1084,8 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 18; ii < 33; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
     }
 
@@ -1172,24 +1103,22 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     for (ii = 33; ii < 36; ii++)
     {
         OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_EnvelopeCalc(&chip->slot[ii]);
+        OPL3_PhaseGenerate(&chip->slot[ii]);
         OPL3_SlotGenerate(&chip->slot[ii]);
     }
-
-    OPL3_NoiseGenerate(chip);
 
     if ((chip->timer & 0x3f) == 0x3f)
     {
         chip->tremolopos = (chip->tremolopos + 1) % 210;
-        if (chip->tremolopos < 105)
-        {
-            chip->tremolo = chip->tremolopos >> chip->tremoloshift;
-        }
-        else
-        {
-            chip->tremolo = (210 - chip->tremolopos) >> chip->tremoloshift;
-        }
+    }
+    if (chip->tremolopos < 105)
+    {
+        chip->tremolo = chip->tremolopos >> chip->tremoloshift;
+    }
+    else
+    {
+        chip->tremolo = (210 - chip->tremolopos) >> chip->tremoloshift;
     }
 
     if ((chip->timer & 0x3ff) == 0x3ff)
@@ -1198,6 +1127,52 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
     }
 
     chip->timer++;
+
+    chip->eg_add = 0;
+    if (chip->eg_timer)
+    {
+        while (shift < 36 && ((chip->eg_timer >> shift) & 1) == 0)
+        {
+            shift++;
+        }
+        if (shift > 12)
+        {
+            chip->eg_add = 0;
+        }
+        else
+        {
+            chip->eg_add = shift + 1;
+        }
+    }
+
+    if (chip->eg_timerrem || chip->eg_state)
+    {
+        if (chip->eg_timer == 0xfffffffff)
+        {
+            chip->eg_timer = 0;
+            chip->eg_timerrem = 1;
+        }
+        else
+        {
+            chip->eg_timer++;
+            chip->eg_timerrem = 0;
+        }
+    }
+
+    chip->eg_state ^= 1;
+
+    while (chip->writebuf[chip->writebuf_cur].time <= chip->writebuf_samplecnt)
+    {
+        if (!(chip->writebuf[chip->writebuf_cur].reg & 0x200))
+        {
+            break;
+        }
+        chip->writebuf[chip->writebuf_cur].reg &= 0x1ff;
+        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_cur].reg,
+                      chip->writebuf[chip->writebuf_cur].data);
+        chip->writebuf_cur = (chip->writebuf_cur + 1) % OPL_WRITEBUF_SIZE;
+    }
+    chip->writebuf_samplecnt++;
 }
 
 void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf)
@@ -1228,8 +1203,9 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
         chip->slot[slotnum].mod = &chip->zeromod;
         chip->slot[slotnum].eg_rout = 0x1ff;
         chip->slot[slotnum].eg_out = 0x1ff;
-        chip->slot[slotnum].eg_gen = envelope_gen_num_off;
+        chip->slot[slotnum].eg_gen = envelope_gen_num_release;
         chip->slot[slotnum].trem = (Bit8u*)&chip->zeromod;
+        chip->slot[slotnum].slot_num = slotnum;
     }
     for (channum = 0; channum < 18; channum++)
     {
@@ -1251,12 +1227,15 @@ void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
         chip->channel[channum].out[2] = &chip->zeromod;
         chip->channel[channum].out[3] = &chip->zeromod;
         chip->channel[channum].chtype = ch_2op;
-        chip->channel[channum].cha = ~0;
-        chip->channel[channum].chb = ~0;
+        chip->channel[channum].cha = 0xffff;
+        chip->channel[channum].chb = 0xffff;
+        chip->channel[channum].ch_num = channum;
         OPL3_ChannelSetupAlg(&chip->channel[channum]);
     }
-    chip->noise = 0x306600;
+    chip->noise = 1;
     chip->rateratio = (samplerate << RSM_FRAC) / 49716;
+    chip->tremoloshift = 4;
+    chip->vibshift = 1;
 }
 
 void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
@@ -1355,5 +1334,51 @@ void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
             OPL3_ChannelWriteC0(&chip->channel[9 * high + (regm & 0x0f)], v);
         }
         break;
+    }
+}
+
+void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v)
+{
+    Bit64u time1, time2;
+
+    if (chip->writebuf[chip->writebuf_last].reg & 0x200)
+    {
+        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_last].reg & 0x1ff,
+                      chip->writebuf[chip->writebuf_last].data);
+
+        chip->writebuf_cur = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+        chip->writebuf_samplecnt = chip->writebuf[chip->writebuf_last].time;
+    }
+
+    chip->writebuf[chip->writebuf_last].reg = reg | 0x200;
+    chip->writebuf[chip->writebuf_last].data = v;
+    time1 = chip->writebuf_lasttime + OPL_WRITEBUF_DELAY;
+    time2 = chip->writebuf_samplecnt;
+
+    if (time1 < time2)
+    {
+        time1 = time2;
+    }
+
+    chip->writebuf[chip->writebuf_last].time = time1;
+    chip->writebuf_lasttime = time1;
+    chip->writebuf_last = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+}
+
+void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
+{
+    Bit32u i;
+
+    for(i = 0; i < numsamples; i++)
+    {
+        if (chip->rateratio == 1 << RSM_FRAC)
+        {
+            OPL3_Generate(chip, sndptr);
+        }
+        else
+        {
+            OPL3_GenerateResampled(chip, sndptr);
+        }
+        sndptr += 2;
     }
 }

--- a/opl3windows/driver/fmopl3lib/opl3.h
+++ b/opl3windows/driver/fmopl3lib/opl3.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2013-2016 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -20,20 +20,30 @@
 //          Tremolo and phase generator calculation information.
 //      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
 //          OPL2 ROMs.
+//      siliconpr0n.org(John McMaster, digshadow):
+//          YMF262 and VRC VII decaps and die shots.
 //
-// version: 1.7.1
+// version: 1.8
 //
 
-#include <stdint.h>
+#ifndef OPL_OPL3_H
+#define OPL_OPL3_H
 
-typedef uint8_t             Bit8u;
-typedef int8_t              Bit8s;
-typedef uint16_t            Bit16u;
-typedef int16_t             Bit16s;
-typedef uint32_t            Bit32u;
-typedef int32_t             Bit32s;
-typedef uint64_t            Bit64u;
-typedef int64_t             Bit64s;
+#include <inttypes.h>
+
+#define OPL_WRITEBUF_SIZE   1024
+#define OPL_WRITEBUF_DELAY  2
+
+typedef uintptr_t       Bitu;
+typedef intptr_t        Bits;
+typedef uint64_t        Bit64u;
+typedef int64_t         Bit64s;
+typedef uint32_t        Bit32u;
+typedef int32_t         Bit32s;
+typedef uint16_t        Bit16u;
+typedef int16_t         Bit16s;
+typedef uint8_t         Bit8u;
+typedef int8_t          Bit8s;
 
 typedef struct _opl3_slot opl3_slot;
 typedef struct _opl3_channel opl3_channel;
@@ -65,8 +75,10 @@ struct _opl3_slot {
     Bit8u reg_rr;
     Bit8u reg_wf;
     Bit8u key;
+    Bit32u pg_reset;
     Bit32u pg_phase;
-    Bit32u timer;
+    Bit16u pg_phase_out;
+    Bit8u slot_num;
 };
 
 struct _opl3_channel {
@@ -82,12 +94,23 @@ struct _opl3_channel {
     Bit8u alg;
     Bit8u ksv;
     Bit16u cha, chb;
+    Bit8u ch_num;
 };
+
+typedef struct _opl3_writebuf {
+    Bit64u time;
+    Bit16u reg;
+    Bit8u data;
+} opl3_writebuf;
 
 struct _opl3_chip {
     opl3_channel channel[18];
     opl3_slot slot[36];
     Bit16u timer;
+    Bit64u eg_timer;
+    Bit8u eg_timerrem;
+    Bit8u eg_state;
+    Bit8u eg_add;
     Bit8u newm;
     Bit8u nts;
     Bit8u rhy;
@@ -99,14 +122,29 @@ struct _opl3_chip {
     Bit32u noise;
     Bit16s zeromod;
     Bit32s mixbuff[2];
+    Bit8u rm_hh_bit2;
+    Bit8u rm_hh_bit3;
+    Bit8u rm_hh_bit7;
+    Bit8u rm_hh_bit8;
+    Bit8u rm_tc_bit3;
+    Bit8u rm_tc_bit5;
     //OPL3L
     Bit32s rateratio;
     Bit32s samplecnt;
     Bit16s oldsamples[2];
     Bit16s samples[2];
+
+    Bit64u writebuf_samplecnt;
+    Bit32u writebuf_cur;
+    Bit32u writebuf_last;
+    Bit64u writebuf_lasttime;
+    opl3_writebuf writebuf[OPL_WRITEBUF_SIZE];
 };
 
 void OPL3_Generate(opl3_chip *chip, Bit16s *buf);
 void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf);
 void OPL3_Reset(opl3_chip *chip, Bit32u samplerate);
 void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v);
+void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v);
+void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
+#endif

--- a/opl3windows/driver/fmopl3lib/opl3class.cpp
+++ b/opl3windows/driver/fmopl3lib/opl3class.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2015-2017 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -15,48 +15,19 @@
 #include <string.h>
 #include "opl3class.h"
 
-const Bit64u lat = (50 * 49716) / 1000;
-
 
 int opl3class::fm_init(unsigned int rate) {
     OPL3_Reset(&chip, rate);
-
-    memset(command,0,sizeof(command));
-    memset(time, 0, sizeof(time));
-    counter = 0;
-    lastwrite = 0;
-    strpos = 0;
-    endpos = 0;
 
 	return 1;
 }
 
 void opl3class::fm_writereg(unsigned short reg, unsigned char data) {
-    command[endpos % 8192][0] = reg;
-    command[endpos % 8192][1] = data;
-    Bit64u t1 = lastwrite + 2;
-    Bit64u t2 = counter + lat;
-    if (t2 > t1)
-    {
-        t1 = t2;
-    }
-    time[endpos % 8192] = t1;
-    lastwrite = t1;
-    endpos = (endpos + 1) % 8192;
+    OPL3_WriteRegBuffered(&chip, reg, data);
 }
 
 void opl3class::fm_generate(signed short *buffer, unsigned int len) {
-    for (unsigned int i = 0; i < len; i++)
-    {
-        while (strpos != endpos && time[strpos] < counter)
-        {
-            OPL3_WriteReg(&chip, command[strpos][0], command[strpos][1]);
-            strpos = (strpos + 1) % 8192;
-        }
-        OPL3_Generate(&chip, (Bit16s*)buffer);
-        buffer += 2;
-        counter++;
-    }
+    OPL3_GenerateStream(&chip, buffer, len);
 }
 
 fm_chip *getchip() {

--- a/opl3windows/driver/fmopl3lib/opl3class.h
+++ b/opl3windows/driver/fmopl3lib/opl3class.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015 Alexey Khokholov (Nuke.YKT)
+// Copyright (C) 2015-2017 Alexey Khokholov (Nuke.YKT)
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -12,19 +12,13 @@
 // GNU General Public License for more details.
 //
 
-#include "..\interface.h"
+#include "../interface.h"
 #include "opl3.h"
 
 
 class opl3class : public fm_chip {
 private:
     opl3_chip chip;
-    Bit64u counter;
-    Bit64u lastwrite;
-    Bit16u command[8192][2];
-    Bit64u time[8192];
-    Bit16u strpos;
-    Bit16s endpos;
 public:
 	int fm_init(unsigned int rate);
 	void fm_writereg(unsigned short reg, unsigned char data);


### PR DESCRIPTION
This pull request upgrades Nuked OPL3 to the latest version and only resamples audio If the emulator is set to run at a sample rate other than the native OPL3 sample rate.